### PR TITLE
Handle cmark parsing options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,10 @@ CMARK_BUILD_DIR=$(CMARK_SRC_DIR)/build
 PYTHON=python3
 CMARK_SPECS_DIR=$(CMARK_SRC_DIR)/test
 CMARK_SPECS_FILE=$(CMARK_SPECS_DIR)/spec.txt
+CMARK_SMART_PUNCT_FILE=$(CMARK_SPECS_DIR)/smart_punct.txt
 CMARK_SPECS_RUNNER=$(CMARK_SPECS_DIR)/spec_tests.py
 CMARK_SPECS_JSON=$(TEST_DIR)/$(CMARK)_specs.json
+CMARK_SMART_PUNCT_JSON=$(TEST_DIR)/$(CMARK)_smart_punct.json
 
 C_SRC_DIR=c_src
 C_SRC_C_FILES=$(sort $(wildcard $(C_SRC_DIR)/*.c))
@@ -75,7 +77,7 @@ $(CMARK):
 
 ### TEST
 
-spec: all $(CMARK_SPECS_JSON)
+spec: all $(CMARK_SPECS_JSON) $(CMARK_SMART_PUNCT_JSON)
 	@mix deps.get
 	@mix test
 
@@ -145,12 +147,20 @@ dev-prebuilt-lib: $(CMARK_SRC_DIR)
 dev-build-objects: dev-copy-code build-objects
 
 $(CMARK_SPECS_JSON): dev-spec-dump
+$(CMARK_SMART_PUNCT_JSON): dev-smart-punct-dump
 
 dev-spec-dump: $(CMARK_SRC_DIR)
 	@$(PYTHON) $(CMARK_SPECS_RUNNER) \
 	--spec $(CMARK_SPECS_FILE) \
 	--dump-tests | \
 	jq -r -M -S "." > $(CMARK_SPECS_JSON) \
+	|| true
+
+dev-smart-punct-dump: $(CMARK_SRC_DIR)
+	@$(PYTHON) $(CMARK_SPECS_RUNNER) \
+	--spec $(CMARK_SMART_PUNCT_FILE) \
+	--dump-tests | \
+	jq -r -M -S "." > $(CMARK_SMART_PUNCT_JSON) \
 	|| true
 
 ### PHONY

--- a/lib/cmark.ex
+++ b/lib/cmark.ex
@@ -6,12 +6,22 @@ defmodule Cmark do
 
   * `to_html/1`
   * `to_html/2`
-  * `to_html_each/2`
+  * `to_html/3`
+  * `to_html_each/3`
 
   """
 
+  @flags [
+    sourcepos: 1,
+    hardbreaks: 2,
+    normalize: 4,
+    smart: 8,
+    validate_utf8: 16,
+    safe: 32
+  ]
+
   @doc """
-  Compiles one or more (list) Markdown documents to HTML and returns result
+  Compiles one or more (list) Markdown documents to HTML and returns result.
 
   ## Examples
 
@@ -24,11 +34,49 @@ defmodule Cmark do
       "<p><code>of documents</code></p>\\n"]
 
   """
-  def to_html(data) when is_list(data),      do: parse_doc_list(data)
-  def to_html(data) when is_bitstring(data), do: parse_doc(data)
+  def to_html(data) when is_list(data) do
+    parse_doc_list(data, [])
+  end
+
+  def to_html(data) when is_bitstring(data) do
+    parse_doc(data, [])
+  end
 
   @doc """
-  Compiles one or more (list) Markdown documents to HTML and calls function with result
+  Compiles one or more (list) Markdown documents to HTML using provided options
+  and returns result.
+
+  Options are passed as a list of atoms.  Available options are:
+
+  * `:sourcepos` - Include a `data-sourcepos` attribute on all block elements.
+  * `:softbreak` - Render `softbreak` elements as hard line breaks.
+  * `:normalize` - Normalize tree by consolidating adjacent text nodes.
+  * `:smart` - Convert straight quotes to curly, --- to em dashes, -- to en dashes.
+  * `:validate_utf8` - Validate UTF-8 in the input before parsing, replacing
+     illegal sequences with the replacement character U+FFFD.
+  * `:safe` - Suppress raw HTML and unsafe links (`javascript:`, `vbscript:`,
+    `file:`, and `data:`, except for `image/png`, `image/gif`, `image/jpeg`, or
+    `image/webp` mime types).  Raw HTML is replaced by a placeholder HTML
+    comment. Unsafe links are replaced by empty strings.
+
+
+  ## Examples
+
+      iex> Cmark.to_html(~s(Use option to enable "smart" quotes.), [:smart])
+      "<p>Use option to enable “smart” quotes.</p>\\n"
+
+  """
+
+  def to_html(data, options) when is_list(data) and is_list(options) do
+    parse_doc_list(data, options)
+  end
+
+  def to_html(data, options) when is_bitstring(data) and is_list(options) do
+    parse_doc(data, options)
+  end
+
+  @doc """
+  Compiles one or more (list) Markdown documents to HTML and calls function with result.
 
   ## Examples
 
@@ -43,11 +91,38 @@ defmodule Cmark do
       "<p>list</p><hr><p>test</p>"
 
   """
-  def to_html(data, callback) when is_list(data),      do: parse_doc_list(data, callback)
-  def to_html(data, callback) when is_bitstring(data), do: parse_doc(data, callback)
+  def to_html(data, callback) when is_list(data) and is_function(callback) do
+    parse_doc_list(data, callback, [])
+  end
+
+  def to_html(data, callback) when is_bitstring(data) and is_function(callback) do
+    parse_doc(data, callback, [])
+  end
 
   @doc """
-  Compiles a list of Markdown documents and calls function for each item
+  Compiles one or more (list) Markdown documents to HTML using provided options
+  and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (htmls) ->
+      iex>   Enum.map(htmls, &String.strip/1) |> Enum.join("<hr>")
+      iex> end
+      iex> ["en-dash --", "ellipsis..."] |> Cmark.to_html(callback, [:smart])
+      "<p>en-dash –</p><hr><p>ellipsis…</p>"
+
+  """
+  def to_html(data, callback, options) when is_list(data) and is_list(options) do
+    parse_doc_list(data, callback, options)
+  end
+
+  def to_html(data, callback, options) when is_bitstring(data) and is_list(options) do
+    parse_doc(data, callback, options)
+  end
+
+  @doc """
+  Compiles a list of Markdown documents using provided options and calls
+  function for each item.
 
   ## Examples
 
@@ -56,31 +131,39 @@ defmodule Cmark do
       ["HTML is <p>list</p>", "HTML is <p>test</p>"]
 
   """
-  def to_html_each(data, callback) when is_list(data) do
-    parse_doc_list_each(data, callback)
+  def to_html_each(data, callback, options \\ []) when is_list(data) do
+    parse_doc_list_each(data, callback, options)
   end
 
-  defp parse_doc_list(documents) do
+
+  defp parse_doc_list(documents, callback, options) when is_function(callback) do
+    callback.(parse_doc_list(documents, options))
+  end
+
+  defp parse_doc_list(documents, options) when is_list(options) do
     documents
-    |> Enum.map(&Task.async(fn -> parse_doc(&1) end))
+    |> Enum.map(&Task.async(fn -> parse_doc(&1, options) end))
     |> Enum.map(&Task.await(&1))
   end
 
-  defp parse_doc_list(documents, callback) do
-    callback.(parse_doc_list(documents))
-  end
 
-  defp parse_doc_list_each(documents, callback) do
+  defp parse_doc_list_each(documents, callback, options) do
     documents
-    |> Enum.map(&Task.async(fn -> parse_doc(&1, callback) end))
+    |> Enum.map(&Task.async(fn -> parse_doc(&1, callback, options) end))
     |> Enum.map(&Task.await(&1))
   end
 
-  defp parse_doc(document) do
-    Cmark.Nif.to_html(document)
+
+  defp parse_doc(document, callback, options) do
+    callback.(parse_doc(document, options))
   end
 
-  defp parse_doc(document, callback) do
-    callback.(Cmark.Nif.to_html(document))
+  defp parse_doc(document, options) do
+    Cmark.Nif.to_html(document, parse_options(options))
+  end
+
+
+  defp parse_options(options) do
+    Enum.reduce(options, 0, fn(flag, acc) -> @flags[flag] + acc end)
   end
 end

--- a/lib/cmark/nif.ex
+++ b/lib/cmark/nif.ex
@@ -26,7 +26,7 @@ defmodule Cmark.Nif do
   end
 
   @doc false
-  def to_html(_) do
+  def to_html(_, _) do
     exit(:nif_library_not_loaded)
   end
 end

--- a/src/cmark_nif.c
+++ b/src/cmark_nif.c
@@ -13,9 +13,9 @@ static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
   ErlNifBinary  output_binary;
   char         *html;
   size_t        html_len;
-  int           options = 0;
+  int           options;
 
-  if (argc != 1) {
+  if (argc != 2) {
     return enif_make_badarg(env);
   }
 
@@ -31,6 +31,8 @@ static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     return enif_make_binary(env, &output_binary);
   }
 
+  enif_get_int(env, argv[1], &options);
+
   html = cmark_markdown_to_html((const char *)markdown_binary.data, markdown_binary.size, options);
   html_len = strlen(html);
   enif_release_binary(&markdown_binary);
@@ -42,7 +44,7 @@ static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 };
 
 static ErlNifFunc nif_funcs[] = {
-  { "to_html", 1, to_html_nif }
+  { "to_html", 2, to_html_nif }
 };
 
 ERL_NIF_INIT(Elixir.Cmark.Nif, nif_funcs, NULL, NULL, NULL, NULL);

--- a/test/cmark_smart_punct.json
+++ b/test/cmark_smart_punct.json
@@ -1,0 +1,122 @@
+[
+  {
+    "end_line": 13,
+    "example": 1,
+    "html": "<p>“Hello,” said the spider.\n“‘Shelob’ is my name.”</p>\n",
+    "markdown": "\"Hello,\" said the spider.\n\"'Shelob' is my name.\"\n",
+    "section": "Smart punctuation",
+    "start_line": 7
+  },
+  {
+    "end_line": 19,
+    "example": 2,
+    "html": "<p>‘A’, ‘B’, and ‘C’ are letters.</p>\n",
+    "markdown": "'A', 'B', and 'C' are letters.\n",
+    "section": "Smart punctuation",
+    "start_line": 15
+  },
+  {
+    "end_line": 27,
+    "example": 3,
+    "html": "<p>‘Oak,’ ‘elm,’ and ‘beech’ are names of trees.\nSo is ‘pine.’</p>\n",
+    "markdown": "'Oak,' 'elm,' and 'beech' are names of trees.\nSo is 'pine.'\n",
+    "section": "Smart punctuation",
+    "start_line": 21
+  },
+  {
+    "end_line": 33,
+    "example": 4,
+    "html": "<p>‘He said, “I want to go.”’</p>\n",
+    "markdown": "'He said, \"I want to go.\"'\n",
+    "section": "Smart punctuation",
+    "start_line": 29
+  },
+  {
+    "end_line": 43,
+    "example": 5,
+    "html": "<p>Were you alive in the 70’s?</p>\n",
+    "markdown": "Were you alive in the 70's?\n",
+    "section": "Smart punctuation",
+    "start_line": 39
+  },
+  {
+    "end_line": 49,
+    "example": 6,
+    "html": "<p>Here is some quoted ‘<code>code</code>’ and a “<a href=\"url\">quoted link</a>”.</p>\n",
+    "markdown": "Here is some quoted '`code`' and a \"[quoted link](url)\".\n",
+    "section": "Smart punctuation",
+    "start_line": 45
+  },
+  {
+    "end_line": 59,
+    "example": 7,
+    "html": "<p>’tis the season to be ‘jolly’</p>\n",
+    "markdown": "'tis the season to be 'jolly'\n",
+    "section": "Smart punctuation",
+    "start_line": 55
+  },
+  {
+    "end_line": 67,
+    "example": 8,
+    "html": "<p>‘We’ll use Jane’s boat and John’s truck,’ Jenna said.</p>\n",
+    "markdown": "'We'll use Jane's boat and John's truck,' Jenna said.\n",
+    "section": "Smart punctuation",
+    "start_line": 63
+  },
+  {
+    "end_line": 79,
+    "example": 9,
+    "html": "<p>“A paragraph with no closing quote.</p>\n<p>“Second paragraph by same speaker, in fiction.”</p>\n",
+    "markdown": "\"A paragraph with no closing quote.\n\n\"Second paragraph by same speaker, in fiction.\"\n",
+    "section": "Smart punctuation",
+    "start_line": 72
+  },
+  {
+    "end_line": 92,
+    "example": 10,
+    "html": "<p>&quot;This is not smart.&quot;\nThis isn't either.\n5'8&quot;</p>\n",
+    "markdown": "\\\"This is not smart.\\\"\nThis isn\\'t either.\n5\\'8\\\"\n",
+    "section": "Smart punctuation",
+    "start_line": 84
+  },
+  {
+    "end_line": 108,
+    "example": 11,
+    "html": "<p>Some dashes:  em—em\nen–en\nem — em\nen – en\n2–3</p>\n",
+    "markdown": "Some dashes:  em---em\nen--en\nem --- em\nen -- en\n2--3\n",
+    "section": "Smart punctuation",
+    "start_line": 96
+  },
+  {
+    "end_line": 143,
+    "example": 12,
+    "html": "<p>one-\ntwo–\nthree—\nfour––\nfive—–\nsix——\nseven—––\neight––––\nnine———\nthirteen———––.</p>\n",
+    "markdown": "one-\ntwo--\nthree---\nfour----\nfive-----\nsix------\nseven-------\neight--------\nnine---------\nthirteen-------------.\n",
+    "section": "Smart punctuation",
+    "start_line": 121
+  },
+  {
+    "end_line": 151,
+    "example": 13,
+    "html": "<p>Escaped hyphens: -- ---.</p>\n",
+    "markdown": "Escaped hyphens: \\-- \\-\\-\\-.\n",
+    "section": "Smart punctuation",
+    "start_line": 147
+  },
+  {
+    "end_line": 159,
+    "example": 14,
+    "html": "<p>Ellipses…and…and….</p>\n",
+    "markdown": "Ellipses...and...and....\n",
+    "section": "Smart punctuation",
+    "start_line": 155
+  },
+  {
+    "end_line": 168,
+    "example": 15,
+    "html": "<p>No ellipses...</p>\n",
+    "markdown": "No ellipses\\.\\.\\.\n",
+    "section": "Smart punctuation",
+    "start_line": 164
+  }
+]

--- a/test/cmark_specs.json
+++ b/test/cmark_specs.json
@@ -1704,3091 +1704,3107 @@
     "start_line": 3402
   },
   {
-    "end_line": 3434,
+    "end_line": 3447,
     "example": 214,
-    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
-    "markdown": "123456789. ok\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\nbaz\n</code></pre>\n</li>\n</ul>\n",
+    "markdown": "- Foo\n\n      bar\n\n      baz\n",
     "section": "List items",
-    "start_line": 3428
-  },
-  {
-    "end_line": 3440,
-    "example": 215,
-    "html": "<p>1234567890. not ok</p>\n",
-    "markdown": "1234567890. not ok\n",
-    "section": "List items",
-    "start_line": 3436
-  },
-  {
-    "end_line": 3450,
-    "example": 216,
-    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
-    "markdown": "0. ok\n",
-    "section": "List items",
-    "start_line": 3444
-  },
-  {
-    "end_line": 3458,
-    "example": 217,
-    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
-    "markdown": "003. ok\n",
-    "section": "List items",
-    "start_line": 3452
+    "start_line": 3431
   },
   {
     "end_line": 3466,
+    "example": 215,
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n<pre><code>  baz\n</code></pre>\n",
+    "markdown": "- Foo\n\n      bar\n\n\n      baz\n",
+    "section": "List items",
+    "start_line": 3449
+  },
+  {
+    "end_line": 3476,
+    "example": 216,
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "markdown": "123456789. ok\n",
+    "section": "List items",
+    "start_line": 3470
+  },
+  {
+    "end_line": 3482,
+    "example": 217,
+    "html": "<p>1234567890. not ok</p>\n",
+    "markdown": "1234567890. not ok\n",
+    "section": "List items",
+    "start_line": 3478
+  },
+  {
+    "end_line": 3492,
     "example": 218,
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "markdown": "0. ok\n",
+    "section": "List items",
+    "start_line": 3486
+  },
+  {
+    "end_line": 3500,
+    "example": 219,
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "markdown": "003. ok\n",
+    "section": "List items",
+    "start_line": 3494
+  },
+  {
+    "end_line": 3508,
+    "example": 220,
     "html": "<p>-1. not ok</p>\n",
     "markdown": "-1. not ok\n",
     "section": "List items",
-    "start_line": 3462
+    "start_line": 3504
   },
   {
-    "end_line": 3497,
-    "example": 219,
+    "end_line": 3539,
+    "example": 221,
     "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
     "markdown": "- foo\n\n      bar\n",
     "section": "List items",
-    "start_line": 3485
+    "start_line": 3527
   },
   {
-    "end_line": 3513,
-    "example": 220,
+    "end_line": 3555,
+    "example": 222,
     "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
     "markdown": "  10.  foo\n\n           bar\n",
     "section": "List items",
-    "start_line": 3501
+    "start_line": 3543
   },
   {
-    "end_line": 3531,
-    "example": 221,
+    "end_line": 3573,
+    "example": 223,
     "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
     "markdown": "    indented code\n\nparagraph\n\n    more code\n",
     "section": "List items",
-    "start_line": 3519
+    "start_line": 3561
   },
   {
-    "end_line": 3549,
-    "example": 222,
+    "end_line": 3591,
+    "example": 224,
     "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
     "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
     "section": "List items",
-    "start_line": 3533
+    "start_line": 3575
   },
   {
-    "end_line": 3570,
-    "example": 223,
+    "end_line": 3612,
+    "example": 225,
     "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
     "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
     "section": "List items",
-    "start_line": 3554
+    "start_line": 3596
   },
   {
-    "end_line": 3587,
-    "example": 224,
+    "end_line": 3629,
+    "example": 226,
     "html": "<p>foo</p>\n<p>bar</p>\n",
     "markdown": "   foo\n\nbar\n",
     "section": "List items",
-    "start_line": 3580
+    "start_line": 3622
   },
   {
-    "end_line": 3598,
-    "example": 225,
+    "end_line": 3640,
+    "example": 227,
     "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
     "markdown": "-    foo\n\n  bar\n",
     "section": "List items",
-    "start_line": 3589
+    "start_line": 3631
   },
   {
-    "end_line": 3616,
-    "example": 226,
+    "end_line": 3658,
+    "example": 228,
     "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
     "markdown": "-  foo\n\n   bar\n",
     "section": "List items",
-    "start_line": 3605
+    "start_line": 3647
   },
   {
-    "end_line": 3653,
-    "example": 227,
+    "end_line": 3695,
+    "example": 229,
     "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
     "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
     "section": "List items",
-    "start_line": 3632
-  },
-  {
-    "end_line": 3668,
-    "example": 228,
-    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
-    "markdown": "-\n\n  foo\n",
-    "section": "List items",
-    "start_line": 3659
-  },
-  {
-    "end_line": 3682,
-    "example": 229,
-    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
-    "markdown": "- foo\n-\n- bar\n",
-    "section": "List items",
-    "start_line": 3672
-  },
-  {
-    "end_line": 3696,
-    "example": 230,
-    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
-    "markdown": "- foo\n-   \n- bar\n",
-    "section": "List items",
-    "start_line": 3686
+    "start_line": 3674
   },
   {
     "end_line": 3710,
-    "example": 231,
-    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
-    "markdown": "1. foo\n2.\n3. bar\n",
+    "example": 230,
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "markdown": "-\n\n  foo\n",
     "section": "List items",
-    "start_line": 3700
+    "start_line": 3701
   },
   {
-    "end_line": 3720,
-    "example": 232,
-    "html": "<ul>\n<li></li>\n</ul>\n",
-    "markdown": "*\n",
+    "end_line": 3724,
+    "example": 231,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n-\n- bar\n",
     "section": "List items",
     "start_line": 3714
   },
   {
-    "end_line": 3750,
+    "end_line": 3738,
+    "example": 232,
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "markdown": "- foo\n-   \n- bar\n",
+    "section": "List items",
+    "start_line": 3728
+  },
+  {
+    "end_line": 3752,
     "example": 233,
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "section": "List items",
+    "start_line": 3742
+  },
+  {
+    "end_line": 3762,
+    "example": 234,
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "markdown": "*\n",
+    "section": "List items",
+    "start_line": 3756
+  },
+  {
+    "end_line": 3792,
+    "example": 235,
     "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
     "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
     "section": "List items",
-    "start_line": 3731
-  },
-  {
-    "end_line": 3773,
-    "example": 234,
-    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
-    "section": "List items",
-    "start_line": 3754
-  },
-  {
-    "end_line": 3796,
-    "example": 235,
-    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
-    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
-    "section": "List items",
-    "start_line": 3777
+    "start_line": 3773
   },
   {
     "end_line": 3815,
     "example": 236,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "section": "List items",
+    "start_line": 3796
+  },
+  {
+    "end_line": 3838,
+    "example": 237,
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "section": "List items",
+    "start_line": 3819
+  },
+  {
+    "end_line": 3857,
+    "example": 238,
     "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
     "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
     "section": "List items",
-    "start_line": 3800
+    "start_line": 3842
   },
   {
-    "end_line": 3848,
-    "example": 237,
+    "end_line": 3890,
+    "example": 239,
     "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
     "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
     "section": "List items",
-    "start_line": 3829
+    "start_line": 3871
   },
   {
-    "end_line": 3860,
-    "example": 238,
+    "end_line": 3902,
+    "example": 240,
     "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
     "markdown": "  1.  A paragraph\n    with two lines.\n",
     "section": "List items",
-    "start_line": 3852
+    "start_line": 3894
   },
   {
-    "end_line": 3878,
-    "example": 239,
+    "end_line": 3920,
+    "example": 241,
     "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
     "markdown": "> 1. > Blockquote\ncontinued here.\n",
-    "section": "List items",
-    "start_line": 3864
-  },
-  {
-    "end_line": 3894,
-    "example": 240,
-    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
-    "markdown": "> 1. > Blockquote\n> continued here.\n",
-    "section": "List items",
-    "start_line": 3880
-  },
-  {
-    "end_line": 3922,
-    "example": 241,
-    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- foo\n  - bar\n    - baz\n",
     "section": "List items",
     "start_line": 3906
   },
   {
     "end_line": 3936,
     "example": 242,
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "section": "List items",
+    "start_line": 3922
+  },
+  {
+    "end_line": 3964,
+    "example": 243,
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- foo\n  - bar\n    - baz\n",
+    "section": "List items",
+    "start_line": 3948
+  },
+  {
+    "end_line": 3978,
+    "example": 244,
     "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
     "markdown": "- foo\n - bar\n  - baz\n",
     "section": "List items",
-    "start_line": 3926
+    "start_line": 3968
   },
   {
-    "end_line": 3951,
-    "example": 243,
+    "end_line": 3993,
+    "example": 245,
     "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
     "markdown": "10) foo\n    - bar\n",
     "section": "List items",
-    "start_line": 3940
+    "start_line": 3982
   },
   {
-    "end_line": 3965,
-    "example": 244,
+    "end_line": 4007,
+    "example": 246,
     "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
     "markdown": "10) foo\n   - bar\n",
     "section": "List items",
-    "start_line": 3955
+    "start_line": 3997
   },
   {
-    "end_line": 3979,
-    "example": 245,
+    "end_line": 4021,
+    "example": 247,
     "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
     "markdown": "- - foo\n",
     "section": "List items",
-    "start_line": 3969
+    "start_line": 4011
   },
   {
-    "end_line": 3995,
-    "example": 246,
+    "end_line": 4037,
+    "example": 248,
     "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
     "markdown": "1. - 2. foo\n",
     "section": "List items",
-    "start_line": 3981
+    "start_line": 4023
   },
   {
-    "end_line": 4013,
-    "example": 247,
+    "end_line": 4055,
+    "example": 249,
     "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
     "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
     "section": "List items",
-    "start_line": 3999
+    "start_line": 4041
   },
   {
-    "end_line": 4247,
-    "example": 248,
+    "end_line": 4289,
+    "example": 250,
     "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
     "markdown": "- foo\n- bar\n+ baz\n",
     "section": "Lists",
-    "start_line": 4235
+    "start_line": 4277
   },
   {
-    "end_line": 4261,
-    "example": 249,
+    "end_line": 4303,
+    "example": 251,
     "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
     "markdown": "1. foo\n2. bar\n3) baz\n",
     "section": "Lists",
-    "start_line": 4249
+    "start_line": 4291
   },
   {
-    "end_line": 4277,
-    "example": 250,
+    "end_line": 4319,
+    "example": 252,
     "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
     "markdown": "Foo\n- bar\n- baz\n",
     "section": "Lists",
-    "start_line": 4267
+    "start_line": 4309
   },
   {
-    "end_line": 4290,
-    "example": 251,
+    "end_line": 4332,
+    "example": 253,
     "html": "<p>The number of windows in my house is</p>\n<ol start=\"14\">\n<li>The number of doors is 6.</li>\n</ol>\n",
     "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
     "section": "Lists",
-    "start_line": 4282
+    "start_line": 4324
   },
   {
-    "end_line": 4366,
-    "example": 252,
+    "end_line": 4408,
+    "example": 254,
     "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
     "markdown": "- foo\n\n- bar\n\n\n- baz\n",
     "section": "Lists",
-    "start_line": 4347
+    "start_line": 4389
   },
   {
-    "end_line": 4386,
-    "example": 253,
+    "end_line": 4428,
+    "example": 255,
     "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n<ul>\n<li>baz</li>\n</ul>\n",
     "markdown": "- foo\n\n\n  bar\n- baz\n",
     "section": "Lists",
-    "start_line": 4372
+    "start_line": 4414
   },
   {
-    "end_line": 4411,
-    "example": 254,
+    "end_line": 4453,
+    "example": 256,
     "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n<pre><code>  bim\n</code></pre>\n",
     "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
     "section": "Lists",
-    "start_line": 4390
+    "start_line": 4432
   },
   {
-    "end_line": 4434,
-    "example": 255,
+    "end_line": 4476,
+    "example": 257,
     "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
     "markdown": "- foo\n- bar\n\n\n- baz\n- bim\n",
     "section": "Lists",
-    "start_line": 4418
+    "start_line": 4460
   },
   {
-    "end_line": 4457,
-    "example": 256,
+    "end_line": 4499,
+    "example": 258,
     "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<pre><code>code\n</code></pre>\n",
     "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n\n    code\n",
     "section": "Lists",
-    "start_line": 4436
-  },
-  {
-    "end_line": 4486,
-    "example": 257,
-    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
-    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
-    "section": "Lists",
-    "start_line": 4464
-  },
-  {
-    "end_line": 4506,
-    "example": 258,
-    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
-    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
-    "section": "Lists",
-    "start_line": 4488
+    "start_line": 4478
   },
   {
     "end_line": 4528,
     "example": 259,
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n<li>h</li>\n<li>i</li>\n</ul>\n",
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n   - f\n  - g\n - h\n- i\n",
+    "section": "Lists",
+    "start_line": 4506
+  },
+  {
+    "end_line": 4548,
+    "example": 260,
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "section": "Lists",
+    "start_line": 4530
+  },
+  {
+    "end_line": 4570,
+    "example": 261,
     "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
     "markdown": "- a\n- b\n\n- c\n",
-    "section": "Lists",
-    "start_line": 4511
-  },
-  {
-    "end_line": 4547,
-    "example": 260,
-    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
-    "markdown": "* a\n*\n\n* c\n",
-    "section": "Lists",
-    "start_line": 4532
-  },
-  {
-    "end_line": 4572,
-    "example": 261,
-    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
-    "markdown": "- a\n- b\n\n  c\n- d\n",
     "section": "Lists",
     "start_line": 4553
   },
   {
-    "end_line": 4592,
+    "end_line": 4589,
     "example": 262,
-    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
-    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "markdown": "* a\n*\n\n* c\n",
     "section": "Lists",
     "start_line": 4574
   },
   {
-    "end_line": 4615,
+    "end_line": 4614,
     "example": 263,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "section": "Lists",
+    "start_line": 4595
+  },
+  {
+    "end_line": 4634,
+    "example": 264,
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "section": "Lists",
+    "start_line": 4616
+  },
+  {
+    "end_line": 4657,
+    "example": 265,
     "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
     "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
     "section": "Lists",
-    "start_line": 4596
-  },
-  {
-    "end_line": 4639,
-    "example": 264,
-    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
-    "markdown": "- a\n  - b\n\n    c\n- d\n",
-    "section": "Lists",
-    "start_line": 4621
-  },
-  {
-    "end_line": 4658,
-    "example": 265,
-    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
-    "markdown": "* a\n  > b\n  >\n* c\n",
-    "section": "Lists",
-    "start_line": 4644
+    "start_line": 4638
   },
   {
     "end_line": 4681,
     "example": 266,
-    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
-    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
     "section": "Lists",
     "start_line": 4663
   },
   {
-    "end_line": 4691,
+    "end_line": 4700,
     "example": 267,
-    "html": "<ul>\n<li>a</li>\n</ul>\n",
-    "markdown": "- a\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "markdown": "* a\n  > b\n  >\n* c\n",
     "section": "Lists",
-    "start_line": 4685
-  },
-  {
-    "end_line": 4704,
-    "example": 268,
-    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
-    "markdown": "- a\n  - b\n",
-    "section": "Lists",
-    "start_line": 4693
+    "start_line": 4686
   },
   {
     "end_line": 4723,
-    "example": 269,
-    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
-    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "example": 268,
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
     "section": "Lists",
-    "start_line": 4709
+    "start_line": 4705
   },
   {
-    "end_line": 4742,
-    "example": 270,
-    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
-    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "end_line": 4733,
+    "example": 269,
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "markdown": "- a\n",
     "section": "Lists",
     "start_line": 4727
   },
   {
-    "end_line": 4769,
+    "end_line": 4746,
+    "example": 270,
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "markdown": "- a\n  - b\n",
+    "section": "Lists",
+    "start_line": 4735
+  },
+  {
+    "end_line": 4765,
     "example": 271,
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "section": "Lists",
+    "start_line": 4751
+  },
+  {
+    "end_line": 4784,
+    "example": 272,
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "section": "Lists",
+    "start_line": 4769
+  },
+  {
+    "end_line": 4811,
+    "example": 273,
     "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
     "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
     "section": "Lists",
-    "start_line": 4744
+    "start_line": 4786
   },
   {
-    "end_line": 4781,
-    "example": 272,
+    "end_line": 4823,
+    "example": 274,
     "html": "<p><code>hi</code>lo`</p>\n",
     "markdown": "`hi`lo`\n",
     "section": "Inlines",
-    "start_line": 4777
+    "start_line": 4819
   },
   {
-    "end_line": 4794,
-    "example": 273,
+    "end_line": 4836,
+    "example": 275,
     "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
     "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
     "section": "Backslash escapes",
-    "start_line": 4790
+    "start_line": 4832
   },
   {
-    "end_line": 4803,
-    "example": 274,
+    "end_line": 4845,
+    "example": 276,
     "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
     "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
     "section": "Backslash escapes",
-    "start_line": 4799
+    "start_line": 4841
   },
   {
-    "end_line": 4826,
-    "example": 275,
+    "end_line": 4868,
+    "example": 277,
     "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;</p>\n",
     "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a header\n\\[foo]: /url \"not a reference\"\n",
     "section": "Backslash escapes",
-    "start_line": 4808
+    "start_line": 4850
   },
   {
-    "end_line": 4834,
-    "example": 276,
+    "end_line": 4876,
+    "example": 278,
     "html": "<p>\\<em>emphasis</em></p>\n",
     "markdown": "\\\\*emphasis*\n",
     "section": "Backslash escapes",
-    "start_line": 4830
+    "start_line": 4872
   },
   {
-    "end_line": 4844,
-    "example": 277,
+    "end_line": 4886,
+    "example": 279,
     "html": "<p>foo<br />\nbar</p>\n",
     "markdown": "foo\\\nbar\n",
     "section": "Backslash escapes",
-    "start_line": 4838
+    "start_line": 4880
   },
   {
-    "end_line": 4853,
-    "example": 278,
+    "end_line": 4895,
+    "example": 280,
     "html": "<p><code>\\[\\`</code></p>\n",
     "markdown": "`` \\[\\` ``\n",
     "section": "Backslash escapes",
-    "start_line": 4849
+    "start_line": 4891
   },
   {
-    "end_line": 4860,
-    "example": 279,
+    "end_line": 4902,
+    "example": 281,
     "html": "<pre><code>\\[\\]\n</code></pre>\n",
     "markdown": "    \\[\\]\n",
     "section": "Backslash escapes",
-    "start_line": 4855
+    "start_line": 4897
   },
   {
-    "end_line": 4869,
-    "example": 280,
+    "end_line": 4911,
+    "example": 282,
     "html": "<pre><code>\\[\\]\n</code></pre>\n",
     "markdown": "~~~\n\\[\\]\n~~~\n",
     "section": "Backslash escapes",
-    "start_line": 4862
+    "start_line": 4904
   },
   {
-    "end_line": 4875,
-    "example": 281,
+    "end_line": 4917,
+    "example": 283,
     "html": "<p><a href=\"http://example.com?find=%5C*\">http://example.com?find=\\*</a></p>\n",
     "markdown": "<http://example.com?find=\\*>\n",
     "section": "Backslash escapes",
-    "start_line": 4871
+    "start_line": 4913
   },
   {
-    "end_line": 4881,
-    "example": 282,
+    "end_line": 4923,
+    "example": 284,
     "html": "<a href=\"/bar\\/)\">\n",
     "markdown": "<a href=\"/bar\\/)\">\n",
     "section": "Backslash escapes",
-    "start_line": 4877
+    "start_line": 4919
   },
   {
-    "end_line": 4890,
-    "example": 283,
+    "end_line": 4932,
+    "example": 285,
     "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
     "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
     "section": "Backslash escapes",
-    "start_line": 4886
+    "start_line": 4928
   },
   {
-    "end_line": 4898,
-    "example": 284,
+    "end_line": 4940,
+    "example": 286,
     "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
     "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
     "section": "Backslash escapes",
-    "start_line": 4892
+    "start_line": 4934
   },
   {
-    "end_line": 4907,
-    "example": 285,
+    "end_line": 4949,
+    "example": 287,
     "html": "<pre><code class=\"language-foo+bar\">foo\n</code></pre>\n",
     "markdown": "``` foo\\+bar\nfoo\n```\n",
     "section": "Backslash escapes",
-    "start_line": 4900
-  },
-  {
-    "end_line": 4934,
-    "example": 286,
-    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
-    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
-    "section": "Entities",
-    "start_line": 4926
-  },
-  {
-    "end_line": 4947,
-    "example": 287,
-    "html": "<p># Ӓ Ϡ � �</p>\n",
-    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
-    "section": "Entities",
-    "start_line": 4943
-  },
-  {
-    "end_line": 4958,
-    "example": 288,
-    "html": "<p>&quot; ആ ಫ</p>\n",
-    "markdown": "&#X22; &#XD06; &#xcab;\n",
-    "section": "Entities",
-    "start_line": 4954
-  },
-  {
-    "end_line": 4966,
-    "example": 289,
-    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
-    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
-    "section": "Entities",
-    "start_line": 4962
+    "start_line": 4942
   },
   {
     "end_line": 4976,
+    "example": 288,
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "section": "Entities",
+    "start_line": 4968
+  },
+  {
+    "end_line": 4989,
+    "example": 289,
+    "html": "<p># Ӓ Ϡ � �</p>\n",
+    "markdown": "&#35; &#1234; &#992; &#98765432; &#0;\n",
+    "section": "Entities",
+    "start_line": 4985
+  },
+  {
+    "end_line": 5000,
     "example": 290,
-    "html": "<p>&amp;copy</p>\n",
-    "markdown": "&copy\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
     "section": "Entities",
-    "start_line": 4972
+    "start_line": 4996
   },
   {
-    "end_line": 4985,
+    "end_line": 5008,
     "example": 291,
-    "html": "<p>&amp;MadeUpEntity;</p>\n",
-    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x; &amp;ThisIsWayTooLongToBeAnEntityIsntIt; &amp;hi?;</p>\n",
+    "markdown": "&nbsp &x; &#; &#x; &ThisIsWayTooLongToBeAnEntityIsntIt; &hi?;\n",
     "section": "Entities",
-    "start_line": 4981
-  },
-  {
-    "end_line": 4995,
-    "example": 292,
-    "html": "<a href=\"&ouml;&ouml;.html\">\n",
-    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
-    "section": "Entities",
-    "start_line": 4991
-  },
-  {
-    "end_line": 5001,
-    "example": 293,
-    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
-    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
-    "section": "Entities",
-    "start_line": 4997
-  },
-  {
-    "end_line": 5009,
-    "example": 294,
-    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
-    "section": "Entities",
-    "start_line": 5003
+    "start_line": 5004
   },
   {
     "end_line": 5018,
+    "example": 292,
+    "html": "<p>&amp;copy</p>\n",
+    "markdown": "&copy\n",
+    "section": "Entities",
+    "start_line": 5014
+  },
+  {
+    "end_line": 5027,
+    "example": 293,
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "markdown": "&MadeUpEntity;\n",
+    "section": "Entities",
+    "start_line": 5023
+  },
+  {
+    "end_line": 5037,
+    "example": 294,
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "section": "Entities",
+    "start_line": 5033
+  },
+  {
+    "end_line": 5043,
     "example": 295,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "section": "Entities",
+    "start_line": 5039
+  },
+  {
+    "end_line": 5051,
+    "example": 296,
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "section": "Entities",
+    "start_line": 5045
+  },
+  {
+    "end_line": 5060,
+    "example": 297,
     "html": "<pre><code class=\"language-föö\">foo\n</code></pre>\n",
     "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
     "section": "Entities",
-    "start_line": 5011
+    "start_line": 5053
   },
   {
-    "end_line": 5026,
-    "example": 296,
+    "end_line": 5068,
+    "example": 298,
     "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
     "markdown": "`f&ouml;&ouml;`\n",
     "section": "Entities",
-    "start_line": 5022
+    "start_line": 5064
   },
   {
-    "end_line": 5033,
-    "example": 297,
+    "end_line": 5075,
+    "example": 299,
     "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
     "markdown": "    f&ouml;f&ouml;\n",
     "section": "Entities",
-    "start_line": 5028
+    "start_line": 5070
   },
   {
-    "end_line": 5053,
-    "example": 298,
+    "end_line": 5095,
+    "example": 300,
     "html": "<p><code>foo</code></p>\n",
     "markdown": "`foo`\n",
     "section": "Code spans",
-    "start_line": 5049
+    "start_line": 5091
   },
   {
-    "end_line": 5062,
-    "example": 299,
+    "end_line": 5104,
+    "example": 301,
     "html": "<p><code>foo ` bar</code></p>\n",
     "markdown": "`` foo ` bar  ``\n",
     "section": "Code spans",
-    "start_line": 5058
+    "start_line": 5100
   },
   {
-    "end_line": 5071,
-    "example": 300,
+    "end_line": 5113,
+    "example": 302,
     "html": "<p><code>``</code></p>\n",
     "markdown": "` `` `\n",
     "section": "Code spans",
-    "start_line": 5067
+    "start_line": 5109
   },
   {
-    "end_line": 5081,
-    "example": 301,
+    "end_line": 5123,
+    "example": 303,
     "html": "<p><code>foo</code></p>\n",
     "markdown": "``\nfoo\n``\n",
     "section": "Code spans",
-    "start_line": 5075
+    "start_line": 5117
   },
   {
-    "end_line": 5091,
-    "example": 302,
+    "end_line": 5133,
+    "example": 304,
     "html": "<p><code>foo bar baz</code></p>\n",
     "markdown": "`foo   bar\n  baz`\n",
     "section": "Code spans",
-    "start_line": 5086
+    "start_line": 5128
   },
   {
-    "end_line": 5110,
-    "example": 303,
+    "end_line": 5152,
+    "example": 305,
     "html": "<p><code>foo `` bar</code></p>\n",
     "markdown": "`foo `` bar`\n",
     "section": "Code spans",
-    "start_line": 5106
+    "start_line": 5148
   },
   {
-    "end_line": 5119,
-    "example": 304,
+    "end_line": 5161,
+    "example": 306,
     "html": "<p><code>foo\\</code>bar`</p>\n",
     "markdown": "`foo\\`bar`\n",
     "section": "Code spans",
-    "start_line": 5115
+    "start_line": 5157
   },
   {
-    "end_line": 5134,
-    "example": 305,
+    "end_line": 5176,
+    "example": 307,
     "html": "<p>*foo<code>*</code></p>\n",
     "markdown": "*foo`*`\n",
     "section": "Code spans",
-    "start_line": 5130
-  },
-  {
-    "end_line": 5142,
-    "example": 306,
-    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
-    "markdown": "[not a `link](/foo`)\n",
-    "section": "Code spans",
-    "start_line": 5138
-  },
-  {
-    "end_line": 5151,
-    "example": 307,
-    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
-    "markdown": "`<a href=\"`\">`\n",
-    "section": "Code spans",
-    "start_line": 5147
-  },
-  {
-    "end_line": 5159,
-    "example": 308,
-    "html": "<p><a href=\"`\">`</p>\n",
-    "markdown": "<a href=\"`\">`\n",
-    "section": "Code spans",
-    "start_line": 5155
-  },
-  {
-    "end_line": 5167,
-    "example": 309,
-    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
-    "markdown": "`<http://foo.bar.`baz>`\n",
-    "section": "Code spans",
-    "start_line": 5163
-  },
-  {
-    "end_line": 5175,
-    "example": 310,
-    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
-    "markdown": "<http://foo.bar.`baz>`\n",
-    "section": "Code spans",
-    "start_line": 5171
+    "start_line": 5172
   },
   {
     "end_line": 5184,
-    "example": 311,
-    "html": "<p>```foo``</p>\n",
-    "markdown": "```foo``\n",
+    "example": 308,
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "markdown": "[not a `link](/foo`)\n",
     "section": "Code spans",
     "start_line": 5180
   },
   {
-    "end_line": 5190,
+    "end_line": 5193,
+    "example": 309,
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "markdown": "`<a href=\"`\">`\n",
+    "section": "Code spans",
+    "start_line": 5189
+  },
+  {
+    "end_line": 5201,
+    "example": 310,
+    "html": "<p><a href=\"`\">`</p>\n",
+    "markdown": "<a href=\"`\">`\n",
+    "section": "Code spans",
+    "start_line": 5197
+  },
+  {
+    "end_line": 5209,
+    "example": 311,
+    "html": "<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>\n",
+    "markdown": "`<http://foo.bar.`baz>`\n",
+    "section": "Code spans",
+    "start_line": 5205
+  },
+  {
+    "end_line": 5217,
     "example": 312,
+    "html": "<p><a href=\"http://foo.bar.%60baz\">http://foo.bar.`baz</a>`</p>\n",
+    "markdown": "<http://foo.bar.`baz>`\n",
+    "section": "Code spans",
+    "start_line": 5213
+  },
+  {
+    "end_line": 5226,
+    "example": 313,
+    "html": "<p>```foo``</p>\n",
+    "markdown": "```foo``\n",
+    "section": "Code spans",
+    "start_line": 5222
+  },
+  {
+    "end_line": 5232,
+    "example": 314,
     "html": "<p>`foo</p>\n",
     "markdown": "`foo\n",
     "section": "Code spans",
-    "start_line": 5186
+    "start_line": 5228
   },
   {
-    "end_line": 5399,
-    "example": 313,
+    "end_line": 5441,
+    "example": 315,
     "html": "<p><em>foo bar</em></p>\n",
     "markdown": "*foo bar*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5395
+    "start_line": 5437
   },
   {
-    "end_line": 5408,
-    "example": 314,
+    "end_line": 5450,
+    "example": 316,
     "html": "<p>a * foo bar*</p>\n",
     "markdown": "a * foo bar*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5404
+    "start_line": 5446
   },
   {
-    "end_line": 5418,
-    "example": 315,
+    "end_line": 5460,
+    "example": 317,
     "html": "<p>a*&quot;foo&quot;*</p>\n",
     "markdown": "a*\"foo\"*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5414
+    "start_line": 5456
   },
   {
-    "end_line": 5426,
-    "example": 316,
+    "end_line": 5468,
+    "example": 318,
     "html": "<p>* a *</p>\n",
     "markdown": "* a *\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5422
+    "start_line": 5464
   },
   {
-    "end_line": 5434,
-    "example": 317,
+    "end_line": 5476,
+    "example": 319,
     "html": "<p>foo<em>bar</em></p>\n",
     "markdown": "foo*bar*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5430
+    "start_line": 5472
   },
   {
-    "end_line": 5440,
-    "example": 318,
+    "end_line": 5482,
+    "example": 320,
     "html": "<p>5<em>6</em>78</p>\n",
     "markdown": "5*6*78\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5436
+    "start_line": 5478
   },
   {
-    "end_line": 5448,
-    "example": 319,
+    "end_line": 5490,
+    "example": 321,
     "html": "<p><em>foo bar</em></p>\n",
     "markdown": "_foo bar_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5444
+    "start_line": 5486
   },
   {
-    "end_line": 5457,
-    "example": 320,
+    "end_line": 5499,
+    "example": 322,
     "html": "<p>_ foo bar_</p>\n",
     "markdown": "_ foo bar_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5453
+    "start_line": 5495
   },
   {
-    "end_line": 5466,
-    "example": 321,
+    "end_line": 5508,
+    "example": 323,
     "html": "<p>a_&quot;foo&quot;_</p>\n",
     "markdown": "a_\"foo\"_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5462
-  },
-  {
-    "end_line": 5474,
-    "example": 322,
-    "html": "<p>foo_bar_</p>\n",
-    "markdown": "foo_bar_\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5470
-  },
-  {
-    "end_line": 5480,
-    "example": 323,
-    "html": "<p>5_6_78</p>\n",
-    "markdown": "5_6_78\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5476
-  },
-  {
-    "end_line": 5486,
-    "example": 324,
-    "html": "<p>пристаням_стремятся_</p>\n",
-    "markdown": "пристаням_стремятся_\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5482
-  },
-  {
-    "end_line": 5495,
-    "example": 325,
-    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
-    "markdown": "aa_\"bb\"_cc\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5491
-  },
-  {
-    "end_line": 5505,
-    "example": 326,
-    "html": "<p>foo-<em>(bar)</em></p>\n",
-    "markdown": "foo-_(bar)_\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5501
+    "start_line": 5504
   },
   {
     "end_line": 5516,
-    "example": 327,
-    "html": "<p>_foo*</p>\n",
-    "markdown": "_foo*\n",
+    "example": 324,
+    "html": "<p>foo_bar_</p>\n",
+    "markdown": "foo_bar_\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 5512
   },
   {
-    "end_line": 5525,
-    "example": 328,
-    "html": "<p>*foo bar *</p>\n",
-    "markdown": "*foo bar *\n",
+    "end_line": 5522,
+    "example": 325,
+    "html": "<p>5_6_78</p>\n",
+    "markdown": "5_6_78\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5521
+    "start_line": 5518
+  },
+  {
+    "end_line": 5528,
+    "example": 326,
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "markdown": "пристаням_стремятся_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5524
   },
   {
     "end_line": 5537,
-    "example": 329,
-    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
-    "markdown": "*foo bar\n*\n",
+    "example": 327,
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "markdown": "aa_\"bb\"_cc\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5529
+    "start_line": 5533
   },
   {
     "end_line": 5547,
-    "example": 330,
-    "html": "<p>*(*foo)</p>\n",
-    "markdown": "*(*foo)\n",
+    "example": 328,
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "markdown": "foo-_(bar)_\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 5543
   },
   {
-    "end_line": 5556,
+    "end_line": 5558,
+    "example": 329,
+    "html": "<p>_foo*</p>\n",
+    "markdown": "_foo*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5554
+  },
+  {
+    "end_line": 5567,
+    "example": 330,
+    "html": "<p>*foo bar *</p>\n",
+    "markdown": "*foo bar *\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5563
+  },
+  {
+    "end_line": 5579,
     "example": 331,
+    "html": "<p>*foo bar</p>\n<ul>\n<li></li>\n</ul>\n",
+    "markdown": "*foo bar\n*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5571
+  },
+  {
+    "end_line": 5589,
+    "example": 332,
+    "html": "<p>*(*foo)</p>\n",
+    "markdown": "*(*foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5585
+  },
+  {
+    "end_line": 5598,
+    "example": 333,
     "html": "<p><em>(<em>foo</em>)</em></p>\n",
     "markdown": "*(*foo*)*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5552
+    "start_line": 5594
   },
   {
-    "end_line": 5564,
-    "example": 332,
+    "end_line": 5606,
+    "example": 334,
     "html": "<p><em>foo</em>bar</p>\n",
     "markdown": "*foo*bar\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5560
+    "start_line": 5602
   },
   {
-    "end_line": 5576,
-    "example": 333,
+    "end_line": 5618,
+    "example": 335,
     "html": "<p>_foo bar _</p>\n",
     "markdown": "_foo bar _\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5572
+    "start_line": 5614
   },
   {
-    "end_line": 5585,
-    "example": 334,
+    "end_line": 5627,
+    "example": 336,
     "html": "<p>_(_foo)</p>\n",
     "markdown": "_(_foo)\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5581
+    "start_line": 5623
   },
   {
-    "end_line": 5593,
-    "example": 335,
+    "end_line": 5635,
+    "example": 337,
     "html": "<p><em>(<em>foo</em>)</em></p>\n",
     "markdown": "_(_foo_)_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5589
+    "start_line": 5631
   },
   {
-    "end_line": 5601,
-    "example": 336,
+    "end_line": 5643,
+    "example": 338,
     "html": "<p>_foo_bar</p>\n",
     "markdown": "_foo_bar\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5597
+    "start_line": 5639
   },
   {
-    "end_line": 5607,
-    "example": 337,
+    "end_line": 5649,
+    "example": 339,
     "html": "<p>_пристаням_стремятся</p>\n",
     "markdown": "_пристаням_стремятся\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5603
+    "start_line": 5645
   },
   {
-    "end_line": 5613,
-    "example": 338,
+    "end_line": 5655,
+    "example": 340,
     "html": "<p><em>foo_bar_baz</em></p>\n",
     "markdown": "_foo_bar_baz_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5609
+    "start_line": 5651
   },
   {
-    "end_line": 5623,
-    "example": 339,
+    "end_line": 5665,
+    "example": 341,
     "html": "<p><em>(bar)</em>.</p>\n",
     "markdown": "_(bar)_.\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5619
+    "start_line": 5661
   },
   {
-    "end_line": 5631,
-    "example": 340,
+    "end_line": 5673,
+    "example": 342,
     "html": "<p><strong>foo bar</strong></p>\n",
     "markdown": "**foo bar**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5627
+    "start_line": 5669
   },
   {
-    "end_line": 5640,
-    "example": 341,
+    "end_line": 5682,
+    "example": 343,
     "html": "<p>** foo bar**</p>\n",
     "markdown": "** foo bar**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5636
-  },
-  {
-    "end_line": 5650,
-    "example": 342,
-    "html": "<p>a**&quot;foo&quot;**</p>\n",
-    "markdown": "a**\"foo\"**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5646
-  },
-  {
-    "end_line": 5658,
-    "example": 343,
-    "html": "<p>foo<strong>bar</strong></p>\n",
-    "markdown": "foo**bar**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5654
-  },
-  {
-    "end_line": 5666,
-    "example": 344,
-    "html": "<p><strong>foo bar</strong></p>\n",
-    "markdown": "__foo bar__\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5662
-  },
-  {
-    "end_line": 5675,
-    "example": 345,
-    "html": "<p>__ foo bar__</p>\n",
-    "markdown": "__ foo bar__\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5671
-  },
-  {
-    "end_line": 5684,
-    "example": 346,
-    "html": "<p>__\nfoo bar__</p>\n",
-    "markdown": "__\nfoo bar__\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 5678
   },
   {
-    "end_line": 5693,
+    "end_line": 5692,
+    "example": 344,
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "markdown": "a**\"foo\"**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5688
+  },
+  {
+    "end_line": 5700,
+    "example": 345,
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "markdown": "foo**bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5696
+  },
+  {
+    "end_line": 5708,
+    "example": 346,
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "markdown": "__foo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5704
+  },
+  {
+    "end_line": 5717,
     "example": 347,
+    "html": "<p>__ foo bar__</p>\n",
+    "markdown": "__ foo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5713
+  },
+  {
+    "end_line": 5726,
+    "example": 348,
+    "html": "<p>__\nfoo bar__</p>\n",
+    "markdown": "__\nfoo bar__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5720
+  },
+  {
+    "end_line": 5735,
+    "example": 349,
     "html": "<p>a__&quot;foo&quot;__</p>\n",
     "markdown": "a__\"foo\"__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5689
+    "start_line": 5731
   },
   {
-    "end_line": 5701,
-    "example": 348,
+    "end_line": 5743,
+    "example": 350,
     "html": "<p>foo__bar__</p>\n",
     "markdown": "foo__bar__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5697
+    "start_line": 5739
   },
   {
-    "end_line": 5707,
-    "example": 349,
+    "end_line": 5749,
+    "example": 351,
     "html": "<p>5__6__78</p>\n",
     "markdown": "5__6__78\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5703
+    "start_line": 5745
   },
   {
-    "end_line": 5713,
-    "example": 350,
+    "end_line": 5755,
+    "example": 352,
     "html": "<p>пристаням__стремятся__</p>\n",
     "markdown": "пристаням__стремятся__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5709
+    "start_line": 5751
   },
   {
-    "end_line": 5719,
-    "example": 351,
+    "end_line": 5761,
+    "example": 353,
     "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
     "markdown": "__foo, __bar__, baz__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5715
+    "start_line": 5757
   },
   {
-    "end_line": 5729,
-    "example": 352,
+    "end_line": 5771,
+    "example": 354,
     "html": "<p>foo-<strong>(bar)</strong></p>\n",
     "markdown": "foo-__(bar)__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5725
+    "start_line": 5767
   },
   {
-    "end_line": 5741,
-    "example": 353,
+    "end_line": 5783,
+    "example": 355,
     "html": "<p>**foo bar **</p>\n",
     "markdown": "**foo bar **\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5737
-  },
-  {
-    "end_line": 5753,
-    "example": 354,
-    "html": "<p>**(**foo)</p>\n",
-    "markdown": "**(**foo)\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5749
-  },
-  {
-    "end_line": 5762,
-    "example": 355,
-    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
-    "markdown": "*(**foo**)*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5758
-  },
-  {
-    "end_line": 5770,
-    "example": 356,
-    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
-    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5764
-  },
-  {
-    "end_line": 5776,
-    "example": 357,
-    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
-    "markdown": "**foo \"*bar*\" foo**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5772
-  },
-  {
-    "end_line": 5784,
-    "example": 358,
-    "html": "<p><strong>foo</strong>bar</p>\n",
-    "markdown": "**foo**bar\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5780
+    "start_line": 5779
   },
   {
     "end_line": 5795,
-    "example": 359,
-    "html": "<p>__foo bar __</p>\n",
-    "markdown": "__foo bar __\n",
+    "example": 356,
+    "html": "<p>**(**foo)</p>\n",
+    "markdown": "**(**foo)\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 5791
   },
   {
     "end_line": 5804,
-    "example": 360,
-    "html": "<p>__(__foo)</p>\n",
-    "markdown": "__(__foo)\n",
+    "example": 357,
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "markdown": "*(**foo**)*\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 5800
   },
   {
-    "end_line": 5813,
+    "end_line": 5812,
+    "example": 358,
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5806
+  },
+  {
+    "end_line": 5818,
+    "example": 359,
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5814
+  },
+  {
+    "end_line": 5826,
+    "example": 360,
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "markdown": "**foo**bar\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5822
+  },
+  {
+    "end_line": 5837,
     "example": 361,
+    "html": "<p>__foo bar __</p>\n",
+    "markdown": "__foo bar __\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5833
+  },
+  {
+    "end_line": 5846,
+    "example": 362,
+    "html": "<p>__(__foo)</p>\n",
+    "markdown": "__(__foo)\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5842
+  },
+  {
+    "end_line": 5855,
+    "example": 363,
     "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
     "markdown": "_(__foo__)_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5809
+    "start_line": 5851
   },
   {
-    "end_line": 5821,
-    "example": 362,
+    "end_line": 5863,
+    "example": 364,
     "html": "<p>__foo__bar</p>\n",
     "markdown": "__foo__bar\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5817
+    "start_line": 5859
   },
   {
-    "end_line": 5827,
-    "example": 363,
+    "end_line": 5869,
+    "example": 365,
     "html": "<p>__пристаням__стремятся</p>\n",
     "markdown": "__пристаням__стремятся\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5823
+    "start_line": 5865
   },
   {
-    "end_line": 5833,
-    "example": 364,
+    "end_line": 5875,
+    "example": 366,
     "html": "<p><strong>foo__bar__baz</strong></p>\n",
     "markdown": "__foo__bar__baz__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5829
+    "start_line": 5871
   },
   {
-    "end_line": 5843,
-    "example": 365,
+    "end_line": 5885,
+    "example": 367,
     "html": "<p><strong>(bar)</strong>.</p>\n",
     "markdown": "__(bar)__.\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5839
+    "start_line": 5881
   },
   {
-    "end_line": 5854,
-    "example": 366,
+    "end_line": 5896,
+    "example": 368,
     "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
     "markdown": "*foo [bar](/url)*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5850
+    "start_line": 5892
   },
   {
-    "end_line": 5862,
-    "example": 367,
+    "end_line": 5904,
+    "example": 369,
     "html": "<p><em>foo\nbar</em></p>\n",
     "markdown": "*foo\nbar*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5856
+    "start_line": 5898
   },
   {
-    "end_line": 5871,
-    "example": 368,
+    "end_line": 5913,
+    "example": 370,
     "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
     "markdown": "_foo __bar__ baz_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5867
+    "start_line": 5909
   },
   {
-    "end_line": 5877,
-    "example": 369,
+    "end_line": 5919,
+    "example": 371,
     "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
     "markdown": "_foo _bar_ baz_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5873
+    "start_line": 5915
   },
   {
-    "end_line": 5883,
-    "example": 370,
+    "end_line": 5925,
+    "example": 372,
     "html": "<p><em><em>foo</em> bar</em></p>\n",
     "markdown": "__foo_ bar_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5879
+    "start_line": 5921
   },
   {
-    "end_line": 5889,
-    "example": 371,
+    "end_line": 5931,
+    "example": 373,
     "html": "<p><em>foo <em>bar</em></em></p>\n",
     "markdown": "*foo *bar**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5885
-  },
-  {
-    "end_line": 5895,
-    "example": 372,
-    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
-    "markdown": "*foo **bar** baz*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5891
-  },
-  {
-    "end_line": 5903,
-    "example": 373,
-    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
-    "markdown": "*foo**bar**baz*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5899
-  },
-  {
-    "end_line": 5912,
-    "example": 374,
-    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
-    "markdown": "***foo** bar*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5908
-  },
-  {
-    "end_line": 5918,
-    "example": 375,
-    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
-    "markdown": "*foo **bar***\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5914
-  },
-  {
-    "end_line": 5928,
-    "example": 376,
-    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
-    "markdown": "*foo**bar***\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 5924
+    "start_line": 5927
   },
   {
     "end_line": 5937,
-    "example": 377,
-    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
-    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "example": 374,
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "markdown": "*foo **bar** baz*\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 5933
   },
   {
-    "end_line": 5943,
+    "end_line": 5945,
+    "example": 375,
+    "html": "<p><em>foo</em><em>bar</em><em>baz</em></p>\n",
+    "markdown": "*foo**bar**baz*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5941
+  },
+  {
+    "end_line": 5954,
+    "example": 376,
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "markdown": "***foo** bar*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5950
+  },
+  {
+    "end_line": 5960,
+    "example": 377,
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "markdown": "*foo **bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5956
+  },
+  {
+    "end_line": 5970,
     "example": 378,
+    "html": "<p><em>foo</em><em>bar</em>**</p>\n",
+    "markdown": "*foo**bar***\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5966
+  },
+  {
+    "end_line": 5979,
+    "example": 379,
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 5975
+  },
+  {
+    "end_line": 5985,
+    "example": 380,
     "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
     "markdown": "*foo [*bar*](/url)*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5939
+    "start_line": 5981
   },
   {
-    "end_line": 5951,
-    "example": 379,
+    "end_line": 5993,
+    "example": 381,
     "html": "<p>** is not an empty emphasis</p>\n",
     "markdown": "** is not an empty emphasis\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5947
+    "start_line": 5989
   },
   {
-    "end_line": 5957,
-    "example": 380,
+    "end_line": 5999,
+    "example": 382,
     "html": "<p>**** is not an empty strong emphasis</p>\n",
     "markdown": "**** is not an empty strong emphasis\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5953
+    "start_line": 5995
   },
   {
-    "end_line": 5969,
-    "example": 381,
+    "end_line": 6011,
+    "example": 383,
     "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
     "markdown": "**foo [bar](/url)**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5965
+    "start_line": 6007
   },
   {
-    "end_line": 5977,
-    "example": 382,
+    "end_line": 6019,
+    "example": 384,
     "html": "<p><strong>foo\nbar</strong></p>\n",
     "markdown": "**foo\nbar**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5971
+    "start_line": 6013
   },
   {
-    "end_line": 5986,
-    "example": 383,
+    "end_line": 6028,
+    "example": 385,
     "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
     "markdown": "__foo _bar_ baz__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5982
+    "start_line": 6024
   },
   {
-    "end_line": 5992,
-    "example": 384,
+    "end_line": 6034,
+    "example": 386,
     "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
     "markdown": "__foo __bar__ baz__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5988
+    "start_line": 6030
   },
   {
-    "end_line": 5998,
-    "example": 385,
+    "end_line": 6040,
+    "example": 387,
     "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
     "markdown": "____foo__ bar__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 5994
+    "start_line": 6036
   },
   {
-    "end_line": 6004,
-    "example": 386,
+    "end_line": 6046,
+    "example": 388,
     "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
     "markdown": "**foo **bar****\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6000
+    "start_line": 6042
   },
   {
-    "end_line": 6010,
-    "example": 387,
+    "end_line": 6052,
+    "example": 389,
     "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
     "markdown": "**foo *bar* baz**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6006
+    "start_line": 6048
   },
   {
-    "end_line": 6018,
-    "example": 388,
+    "end_line": 6060,
+    "example": 390,
     "html": "<p><em><em>foo</em>bar</em>baz**</p>\n",
     "markdown": "**foo*bar*baz**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6014
+    "start_line": 6056
   },
   {
-    "end_line": 6027,
-    "example": 389,
+    "end_line": 6069,
+    "example": 391,
     "html": "<p><strong><em>foo</em> bar</strong></p>\n",
     "markdown": "***foo* bar**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6023
+    "start_line": 6065
   },
   {
-    "end_line": 6033,
-    "example": 390,
+    "end_line": 6075,
+    "example": 392,
     "html": "<p><strong>foo <em>bar</em></strong></p>\n",
     "markdown": "**foo *bar***\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6029
+    "start_line": 6071
   },
   {
-    "end_line": 6043,
-    "example": 391,
+    "end_line": 6085,
+    "example": 393,
     "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
     "markdown": "**foo *bar **baz**\nbim* bop**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6037
+    "start_line": 6079
   },
   {
-    "end_line": 6049,
-    "example": 392,
+    "end_line": 6091,
+    "example": 394,
     "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
     "markdown": "**foo [*bar*](/url)**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6045
+    "start_line": 6087
   },
   {
-    "end_line": 6057,
-    "example": 393,
+    "end_line": 6099,
+    "example": 395,
     "html": "<p>__ is not an empty emphasis</p>\n",
     "markdown": "__ is not an empty emphasis\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6053
+    "start_line": 6095
   },
   {
-    "end_line": 6063,
-    "example": 394,
+    "end_line": 6105,
+    "example": 396,
     "html": "<p>____ is not an empty strong emphasis</p>\n",
     "markdown": "____ is not an empty strong emphasis\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6059
+    "start_line": 6101
   },
   {
-    "end_line": 6072,
-    "example": 395,
+    "end_line": 6114,
+    "example": 397,
     "html": "<p>foo ***</p>\n",
     "markdown": "foo ***\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6068
+    "start_line": 6110
   },
   {
-    "end_line": 6078,
-    "example": 396,
+    "end_line": 6120,
+    "example": 398,
     "html": "<p>foo <em>*</em></p>\n",
     "markdown": "foo *\\**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6074
+    "start_line": 6116
   },
   {
-    "end_line": 6084,
-    "example": 397,
+    "end_line": 6126,
+    "example": 399,
     "html": "<p>foo <em>_</em></p>\n",
     "markdown": "foo *_*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6080
+    "start_line": 6122
   },
   {
-    "end_line": 6090,
-    "example": 398,
+    "end_line": 6132,
+    "example": 400,
     "html": "<p>foo *****</p>\n",
     "markdown": "foo *****\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6086
+    "start_line": 6128
   },
   {
-    "end_line": 6096,
-    "example": 399,
+    "end_line": 6138,
+    "example": 401,
     "html": "<p>foo <strong>*</strong></p>\n",
     "markdown": "foo **\\***\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6092
+    "start_line": 6134
   },
   {
-    "end_line": 6102,
-    "example": 400,
+    "end_line": 6144,
+    "example": 402,
     "html": "<p>foo <strong>_</strong></p>\n",
     "markdown": "foo **_**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6098
+    "start_line": 6140
   },
   {
-    "end_line": 6112,
-    "example": 401,
+    "end_line": 6154,
+    "example": 403,
     "html": "<p>*<em>foo</em></p>\n",
     "markdown": "**foo*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6108
+    "start_line": 6150
   },
   {
-    "end_line": 6118,
-    "example": 402,
+    "end_line": 6160,
+    "example": 404,
     "html": "<p><em>foo</em>*</p>\n",
     "markdown": "*foo**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6114
+    "start_line": 6156
   },
   {
-    "end_line": 6124,
-    "example": 403,
+    "end_line": 6166,
+    "example": 405,
     "html": "<p>*<strong>foo</strong></p>\n",
     "markdown": "***foo**\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6120
+    "start_line": 6162
   },
   {
-    "end_line": 6130,
-    "example": 404,
+    "end_line": 6172,
+    "example": 406,
     "html": "<p>***<em>foo</em></p>\n",
     "markdown": "****foo*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6126
+    "start_line": 6168
   },
   {
-    "end_line": 6136,
-    "example": 405,
+    "end_line": 6178,
+    "example": 407,
     "html": "<p><strong>foo</strong>*</p>\n",
     "markdown": "**foo***\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6132
+    "start_line": 6174
   },
   {
-    "end_line": 6142,
-    "example": 406,
+    "end_line": 6184,
+    "example": 408,
     "html": "<p><em>foo</em>***</p>\n",
     "markdown": "*foo****\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6138
+    "start_line": 6180
   },
   {
-    "end_line": 6151,
-    "example": 407,
+    "end_line": 6193,
+    "example": 409,
     "html": "<p>foo ___</p>\n",
     "markdown": "foo ___\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6147
+    "start_line": 6189
   },
   {
-    "end_line": 6157,
-    "example": 408,
+    "end_line": 6199,
+    "example": 410,
     "html": "<p>foo <em>_</em></p>\n",
     "markdown": "foo _\\__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6153
+    "start_line": 6195
   },
   {
-    "end_line": 6163,
-    "example": 409,
+    "end_line": 6205,
+    "example": 411,
     "html": "<p>foo <em>*</em></p>\n",
     "markdown": "foo _*_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6159
+    "start_line": 6201
   },
   {
-    "end_line": 6169,
-    "example": 410,
+    "end_line": 6211,
+    "example": 412,
     "html": "<p>foo _____</p>\n",
     "markdown": "foo _____\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6165
+    "start_line": 6207
   },
   {
-    "end_line": 6175,
-    "example": 411,
+    "end_line": 6217,
+    "example": 413,
     "html": "<p>foo <strong>_</strong></p>\n",
     "markdown": "foo __\\___\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6171
+    "start_line": 6213
   },
   {
-    "end_line": 6181,
-    "example": 412,
+    "end_line": 6223,
+    "example": 414,
     "html": "<p>foo <strong>*</strong></p>\n",
     "markdown": "foo __*__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6177
+    "start_line": 6219
   },
   {
-    "end_line": 6187,
-    "example": 413,
+    "end_line": 6229,
+    "example": 415,
     "html": "<p>_<em>foo</em></p>\n",
     "markdown": "__foo_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6183
+    "start_line": 6225
   },
   {
-    "end_line": 6197,
-    "example": 414,
+    "end_line": 6239,
+    "example": 416,
     "html": "<p><em>foo</em>_</p>\n",
     "markdown": "_foo__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6193
+    "start_line": 6235
   },
   {
-    "end_line": 6203,
-    "example": 415,
+    "end_line": 6245,
+    "example": 417,
     "html": "<p>_<strong>foo</strong></p>\n",
     "markdown": "___foo__\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6199
+    "start_line": 6241
   },
   {
-    "end_line": 6209,
-    "example": 416,
+    "end_line": 6251,
+    "example": 418,
     "html": "<p>___<em>foo</em></p>\n",
     "markdown": "____foo_\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6205
-  },
-  {
-    "end_line": 6215,
-    "example": 417,
-    "html": "<p><strong>foo</strong>_</p>\n",
-    "markdown": "__foo___\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6211
-  },
-  {
-    "end_line": 6221,
-    "example": 418,
-    "html": "<p><em>foo</em>___</p>\n",
-    "markdown": "_foo____\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6217
-  },
-  {
-    "end_line": 6230,
-    "example": 419,
-    "html": "<p><strong>foo</strong></p>\n",
-    "markdown": "**foo**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6226
-  },
-  {
-    "end_line": 6236,
-    "example": 420,
-    "html": "<p><em><em>foo</em></em></p>\n",
-    "markdown": "*_foo_*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6232
-  },
-  {
-    "end_line": 6242,
-    "example": 421,
-    "html": "<p><strong>foo</strong></p>\n",
-    "markdown": "__foo__\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6238
-  },
-  {
-    "end_line": 6248,
-    "example": 422,
-    "html": "<p><em><em>foo</em></em></p>\n",
-    "markdown": "_*foo*_\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6244
+    "start_line": 6247
   },
   {
     "end_line": 6257,
-    "example": 423,
-    "html": "<p><strong><strong>foo</strong></strong></p>\n",
-    "markdown": "****foo****\n",
+    "example": 419,
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "markdown": "__foo___\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 6253
   },
   {
     "end_line": 6263,
-    "example": 424,
-    "html": "<p><strong><strong>foo</strong></strong></p>\n",
-    "markdown": "____foo____\n",
+    "example": 420,
+    "html": "<p><em>foo</em>___</p>\n",
+    "markdown": "_foo____\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 6259
   },
   {
-    "end_line": 6273,
+    "end_line": 6272,
+    "example": 421,
+    "html": "<p><strong>foo</strong></p>\n",
+    "markdown": "**foo**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6268
+  },
+  {
+    "end_line": 6278,
+    "example": 422,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "markdown": "*_foo_*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6274
+  },
+  {
+    "end_line": 6284,
+    "example": 423,
+    "html": "<p><strong>foo</strong></p>\n",
+    "markdown": "__foo__\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6280
+  },
+  {
+    "end_line": 6290,
+    "example": 424,
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "markdown": "_*foo*_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6286
+  },
+  {
+    "end_line": 6299,
     "example": 425,
-    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
-    "markdown": "******foo******\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "markdown": "****foo****\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6269
+    "start_line": 6295
   },
   {
-    "end_line": 6281,
+    "end_line": 6305,
     "example": 426,
-    "html": "<p><strong><em>foo</em></strong></p>\n",
-    "markdown": "***foo***\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "markdown": "____foo____\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6277
-  },
-  {
-    "end_line": 6287,
-    "example": 427,
-    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
-    "markdown": "_____foo_____\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6283
-  },
-  {
-    "end_line": 6295,
-    "example": 428,
-    "html": "<p><em>foo _bar</em> baz_</p>\n",
-    "markdown": "*foo _bar* baz_\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6291
-  },
-  {
-    "end_line": 6301,
-    "example": 429,
-    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
-    "markdown": "**foo*bar**\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6297
-  },
-  {
-    "end_line": 6307,
-    "example": 430,
-    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
-    "markdown": "*foo __bar *baz bim__ bam*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6303
+    "start_line": 6301
   },
   {
     "end_line": 6315,
-    "example": 431,
-    "html": "<p>**foo <strong>bar baz</strong></p>\n",
-    "markdown": "**foo **bar baz**\n",
+    "example": 427,
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "markdown": "******foo******\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 6311
   },
   {
-    "end_line": 6321,
-    "example": 432,
-    "html": "<p>*foo <em>bar baz</em></p>\n",
-    "markdown": "*foo *bar baz*\n",
+    "end_line": 6323,
+    "example": 428,
+    "html": "<p><strong><em>foo</em></strong></p>\n",
+    "markdown": "***foo***\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6317
+    "start_line": 6319
   },
   {
     "end_line": 6329,
-    "example": 433,
-    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
-    "markdown": "*[bar*](/url)\n",
+    "example": 429,
+    "html": "<p><strong><strong><em>foo</em></strong></strong></p>\n",
+    "markdown": "_____foo_____\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 6325
   },
   {
-    "end_line": 6335,
+    "end_line": 6337,
+    "example": 430,
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "markdown": "*foo _bar* baz_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6333
+  },
+  {
+    "end_line": 6343,
+    "example": 431,
+    "html": "<p><em><em>foo</em>bar</em>*</p>\n",
+    "markdown": "**foo*bar**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6339
+  },
+  {
+    "end_line": 6349,
+    "example": 432,
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6345
+  },
+  {
+    "end_line": 6357,
+    "example": 433,
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "markdown": "**foo **bar baz**\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6353
+  },
+  {
+    "end_line": 6363,
     "example": 434,
-    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
-    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "markdown": "*foo *bar baz*\n",
     "section": "Emphasis and strong emphasis",
-    "start_line": 6331
-  },
-  {
-    "end_line": 6341,
-    "example": 435,
-    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
-    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6337
-  },
-  {
-    "end_line": 6347,
-    "example": 436,
-    "html": "<p>**<a href=\"**\"></p>\n",
-    "markdown": "**<a href=\"**\">\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6343
-  },
-  {
-    "end_line": 6353,
-    "example": 437,
-    "html": "<p>__<a href=\"__\"></p>\n",
-    "markdown": "__<a href=\"__\">\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6349
-  },
-  {
-    "end_line": 6359,
-    "example": 438,
-    "html": "<p><em>a <code>*</code></em></p>\n",
-    "markdown": "*a `*`*\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6355
-  },
-  {
-    "end_line": 6365,
-    "example": 439,
-    "html": "<p><em>a <code>_</code></em></p>\n",
-    "markdown": "_a `_`_\n",
-    "section": "Emphasis and strong emphasis",
-    "start_line": 6361
+    "start_line": 6359
   },
   {
     "end_line": 6371,
-    "example": 440,
-    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
-    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "example": 435,
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "markdown": "*[bar*](/url)\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 6367
   },
   {
     "end_line": 6377,
-    "example": 441,
-    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
-    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "example": 436,
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "markdown": "_foo [bar_](/url)\n",
     "section": "Emphasis and strong emphasis",
     "start_line": 6373
   },
   {
-    "end_line": 6456,
+    "end_line": 6383,
+    "example": 437,
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6379
+  },
+  {
+    "end_line": 6389,
+    "example": 438,
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "markdown": "**<a href=\"**\">\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6385
+  },
+  {
+    "end_line": 6395,
+    "example": 439,
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "markdown": "__<a href=\"__\">\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6391
+  },
+  {
+    "end_line": 6401,
+    "example": 440,
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "markdown": "*a `*`*\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6397
+  },
+  {
+    "end_line": 6407,
+    "example": 441,
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "markdown": "_a `_`_\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6403
+  },
+  {
+    "end_line": 6413,
     "example": 442,
+    "html": "<p>**a<a href=\"http://foo.bar/?q=**\">http://foo.bar/?q=**</a></p>\n",
+    "markdown": "**a<http://foo.bar/?q=**>\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6409
+  },
+  {
+    "end_line": 6419,
+    "example": 443,
+    "html": "<p>__a<a href=\"http://foo.bar/?q=__\">http://foo.bar/?q=__</a></p>\n",
+    "markdown": "__a<http://foo.bar/?q=__>\n",
+    "section": "Emphasis and strong emphasis",
+    "start_line": 6415
+  },
+  {
+    "end_line": 6498,
+    "example": 444,
     "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
     "markdown": "[link](/uri \"title\")\n",
     "section": "Links",
-    "start_line": 6452
+    "start_line": 6494
   },
   {
-    "end_line": 6464,
-    "example": 443,
+    "end_line": 6506,
+    "example": 445,
     "html": "<p><a href=\"/uri\">link</a></p>\n",
     "markdown": "[link](/uri)\n",
     "section": "Links",
-    "start_line": 6460
+    "start_line": 6502
   },
   {
-    "end_line": 6472,
-    "example": 444,
+    "end_line": 6514,
+    "example": 446,
     "html": "<p><a href=\"\">link</a></p>\n",
     "markdown": "[link]()\n",
     "section": "Links",
-    "start_line": 6468
+    "start_line": 6510
   },
   {
-    "end_line": 6478,
-    "example": 445,
+    "end_line": 6520,
+    "example": 447,
     "html": "<p><a href=\"\">link</a></p>\n",
     "markdown": "[link](<>)\n",
     "section": "Links",
-    "start_line": 6474
+    "start_line": 6516
   },
   {
-    "end_line": 6487,
-    "example": 446,
+    "end_line": 6529,
+    "example": 448,
     "html": "<p>[link](/my uri)</p>\n",
     "markdown": "[link](/my uri)\n",
     "section": "Links",
-    "start_line": 6483
+    "start_line": 6525
   },
   {
-    "end_line": 6493,
-    "example": 447,
+    "end_line": 6535,
+    "example": 449,
     "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
     "markdown": "[link](</my uri>)\n",
     "section": "Links",
-    "start_line": 6489
+    "start_line": 6531
   },
   {
-    "end_line": 6503,
-    "example": 448,
+    "end_line": 6545,
+    "example": 450,
     "html": "<p>[link](foo\nbar)</p>\n",
     "markdown": "[link](foo\nbar)\n",
     "section": "Links",
-    "start_line": 6497
+    "start_line": 6539
   },
   {
-    "end_line": 6511,
-    "example": 449,
+    "end_line": 6553,
+    "example": 451,
     "html": "<p>[link](<foo\nbar>)</p>\n",
     "markdown": "[link](<foo\nbar>)\n",
     "section": "Links",
-    "start_line": 6505
+    "start_line": 6547
   },
   {
-    "end_line": 6519,
-    "example": 450,
+    "end_line": 6561,
+    "example": 452,
     "html": "<p><a href=\"(foo)and(bar)\">link</a></p>\n",
     "markdown": "[link]((foo)and(bar))\n",
     "section": "Links",
-    "start_line": 6515
+    "start_line": 6557
   },
   {
-    "end_line": 6528,
-    "example": 451,
+    "end_line": 6570,
+    "example": 453,
     "html": "<p>[link](foo(and(bar)))</p>\n",
     "markdown": "[link](foo(and(bar)))\n",
     "section": "Links",
-    "start_line": 6524
+    "start_line": 6566
   },
   {
-    "end_line": 6534,
-    "example": 452,
+    "end_line": 6576,
+    "example": 454,
     "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
     "markdown": "[link](foo(and\\(bar\\)))\n",
     "section": "Links",
-    "start_line": 6530
+    "start_line": 6572
   },
   {
-    "end_line": 6540,
-    "example": 453,
+    "end_line": 6582,
+    "example": 455,
     "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
     "markdown": "[link](<foo(and(bar))>)\n",
     "section": "Links",
-    "start_line": 6536
+    "start_line": 6578
   },
   {
-    "end_line": 6549,
-    "example": 454,
+    "end_line": 6591,
+    "example": 456,
     "html": "<p><a href=\"foo):\">link</a></p>\n",
     "markdown": "[link](foo\\)\\:)\n",
     "section": "Links",
-    "start_line": 6545
-  },
-  {
-    "end_line": 6563,
-    "example": 455,
-    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=bar&amp;baz#fragment\">link</a></p>\n",
-    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=bar&baz#fragment)\n",
-    "section": "Links",
-    "start_line": 6553
-  },
-  {
-    "end_line": 6572,
-    "example": 456,
-    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
-    "markdown": "[link](foo\\bar)\n",
-    "section": "Links",
-    "start_line": 6568
-  },
-  {
-    "end_line": 6583,
-    "example": 457,
-    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
-    "markdown": "[link](foo%20b&auml;)\n",
-    "section": "Links",
-    "start_line": 6579
-  },
-  {
-    "end_line": 6593,
-    "example": 458,
-    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
-    "markdown": "[link](\"title\")\n",
-    "section": "Links",
-    "start_line": 6589
+    "start_line": 6587
   },
   {
     "end_line": 6605,
+    "example": 457,
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"http://example.com#fragment\">link</a></p>\n<p><a href=\"http://example.com?foo=bar&amp;baz#fragment\">link</a></p>\n",
+    "markdown": "[link](#fragment)\n\n[link](http://example.com#fragment)\n\n[link](http://example.com?foo=bar&baz#fragment)\n",
+    "section": "Links",
+    "start_line": 6595
+  },
+  {
+    "end_line": 6614,
+    "example": 458,
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "markdown": "[link](foo\\bar)\n",
+    "section": "Links",
+    "start_line": 6610
+  },
+  {
+    "end_line": 6625,
     "example": 459,
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "markdown": "[link](foo%20b&auml;)\n",
+    "section": "Links",
+    "start_line": 6621
+  },
+  {
+    "end_line": 6635,
+    "example": 460,
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "markdown": "[link](\"title\")\n",
+    "section": "Links",
+    "start_line": 6631
+  },
+  {
+    "end_line": 6647,
+    "example": 461,
     "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
     "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
     "section": "Links",
-    "start_line": 6597
+    "start_line": 6639
   },
   {
-    "end_line": 6613,
-    "example": 460,
+    "end_line": 6655,
+    "example": 462,
     "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
     "markdown": "[link](/url \"title \\\"&quot;\")\n",
     "section": "Links",
-    "start_line": 6609
+    "start_line": 6651
   },
   {
-    "end_line": 6621,
-    "example": 461,
+    "end_line": 6663,
+    "example": 463,
     "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
     "markdown": "[link](/url \"title \"and\" title\")\n",
     "section": "Links",
-    "start_line": 6617
+    "start_line": 6659
   },
   {
-    "end_line": 6629,
-    "example": 462,
+    "end_line": 6671,
+    "example": 464,
     "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
     "markdown": "[link](/url 'title \"and\" title')\n",
     "section": "Links",
-    "start_line": 6625
+    "start_line": 6667
   },
   {
-    "end_line": 6652,
-    "example": 463,
+    "end_line": 6694,
+    "example": 465,
     "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
     "markdown": "[link](   /uri\n  \"title\"  )\n",
     "section": "Links",
-    "start_line": 6647
+    "start_line": 6689
   },
   {
-    "end_line": 6661,
-    "example": 464,
+    "end_line": 6703,
+    "example": 466,
     "html": "<p>[link] (/uri)</p>\n",
     "markdown": "[link] (/uri)\n",
     "section": "Links",
-    "start_line": 6657
+    "start_line": 6699
   },
   {
-    "end_line": 6670,
-    "example": 465,
+    "end_line": 6712,
+    "example": 467,
     "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
     "markdown": "[link [foo [bar]]](/uri)\n",
     "section": "Links",
-    "start_line": 6666
+    "start_line": 6708
   },
   {
-    "end_line": 6676,
-    "example": 466,
+    "end_line": 6718,
+    "example": 468,
     "html": "<p>[link] bar](/uri)</p>\n",
     "markdown": "[link] bar](/uri)\n",
     "section": "Links",
-    "start_line": 6672
+    "start_line": 6714
   },
   {
-    "end_line": 6682,
-    "example": 467,
+    "end_line": 6724,
+    "example": 469,
     "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
     "markdown": "[link [bar](/uri)\n",
     "section": "Links",
-    "start_line": 6678
+    "start_line": 6720
   },
   {
-    "end_line": 6688,
-    "example": 468,
+    "end_line": 6730,
+    "example": 470,
     "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
     "markdown": "[link \\[bar](/uri)\n",
     "section": "Links",
-    "start_line": 6684
+    "start_line": 6726
   },
   {
-    "end_line": 6696,
-    "example": 469,
+    "end_line": 6738,
+    "example": 471,
     "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
     "markdown": "[link *foo **bar** `#`*](/uri)\n",
     "section": "Links",
-    "start_line": 6692
+    "start_line": 6734
   },
   {
-    "end_line": 6702,
-    "example": 470,
+    "end_line": 6744,
+    "example": 472,
     "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
     "markdown": "[![moon](moon.jpg)](/uri)\n",
     "section": "Links",
-    "start_line": 6698
+    "start_line": 6740
   },
   {
-    "end_line": 6710,
-    "example": 471,
+    "end_line": 6752,
+    "example": 473,
     "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
     "markdown": "[foo [bar](/uri)](/uri)\n",
     "section": "Links",
-    "start_line": 6706
+    "start_line": 6748
   },
   {
-    "end_line": 6716,
-    "example": 472,
+    "end_line": 6758,
+    "example": 474,
     "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
     "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
     "section": "Links",
-    "start_line": 6712
+    "start_line": 6754
   },
   {
-    "end_line": 6722,
-    "example": 473,
+    "end_line": 6764,
+    "example": 475,
     "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
     "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
     "section": "Links",
-    "start_line": 6718
+    "start_line": 6760
   },
   {
-    "end_line": 6731,
-    "example": 474,
+    "end_line": 6773,
+    "example": 476,
     "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
     "markdown": "*[foo*](/uri)\n",
     "section": "Links",
-    "start_line": 6727
+    "start_line": 6769
   },
   {
-    "end_line": 6737,
-    "example": 475,
+    "end_line": 6779,
+    "example": 477,
     "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
     "markdown": "[foo *bar](baz*)\n",
     "section": "Links",
-    "start_line": 6733
+    "start_line": 6775
   },
   {
-    "end_line": 6746,
-    "example": 476,
+    "end_line": 6788,
+    "example": 478,
     "html": "<p><em>foo [bar</em> baz]</p>\n",
     "markdown": "*foo [bar* baz]\n",
     "section": "Links",
-    "start_line": 6742
+    "start_line": 6784
   },
   {
-    "end_line": 6755,
-    "example": 477,
+    "end_line": 6797,
+    "example": 479,
     "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
     "markdown": "[foo <bar attr=\"](baz)\">\n",
     "section": "Links",
-    "start_line": 6751
-  },
-  {
-    "end_line": 6761,
-    "example": 478,
-    "html": "<p>[foo<code>](/uri)</code></p>\n",
-    "markdown": "[foo`](/uri)`\n",
-    "section": "Links",
-    "start_line": 6757
-  },
-  {
-    "end_line": 6767,
-    "example": 479,
-    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
-    "markdown": "[foo<http://example.com/?search=](uri)>\n",
-    "section": "Links",
-    "start_line": 6763
+    "start_line": 6793
   },
   {
     "end_line": 6803,
     "example": 480,
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "markdown": "[foo`](/uri)`\n",
+    "section": "Links",
+    "start_line": 6799
+  },
+  {
+    "end_line": 6809,
+    "example": 481,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D(uri)\">http://example.com/?search=](uri)</a></p>\n",
+    "markdown": "[foo<http://example.com/?search=](uri)>\n",
+    "section": "Links",
+    "start_line": 6805
+  },
+  {
+    "end_line": 6845,
+    "example": 482,
     "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 6797
+    "start_line": 6839
   },
   {
-    "end_line": 6817,
-    "example": 481,
+    "end_line": 6859,
+    "example": 483,
     "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
     "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6811
+    "start_line": 6853
   },
   {
-    "end_line": 6825,
-    "example": 482,
+    "end_line": 6867,
+    "example": 484,
     "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
     "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6819
+    "start_line": 6861
   },
   {
-    "end_line": 6835,
-    "example": 483,
+    "end_line": 6877,
+    "example": 485,
     "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
     "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6829
+    "start_line": 6871
   },
   {
-    "end_line": 6843,
-    "example": 484,
+    "end_line": 6885,
+    "example": 486,
     "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
     "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6837
+    "start_line": 6879
   },
   {
-    "end_line": 6853,
-    "example": 485,
+    "end_line": 6895,
+    "example": 487,
     "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
     "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6847
+    "start_line": 6889
   },
   {
-    "end_line": 6861,
-    "example": 486,
+    "end_line": 6903,
+    "example": 488,
     "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
     "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6855
+    "start_line": 6897
   },
   {
-    "end_line": 6875,
-    "example": 487,
+    "end_line": 6917,
+    "example": 489,
     "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
     "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6869
+    "start_line": 6911
   },
   {
-    "end_line": 6883,
-    "example": 488,
+    "end_line": 6925,
+    "example": 490,
     "html": "<p><a href=\"/uri\">foo *bar</a></p>\n",
     "markdown": "[foo *bar][ref]\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6877
+    "start_line": 6919
   },
   {
-    "end_line": 6894,
-    "example": 489,
+    "end_line": 6936,
+    "example": 491,
     "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
     "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6888
+    "start_line": 6930
   },
   {
-    "end_line": 6902,
-    "example": 490,
+    "end_line": 6944,
+    "example": 492,
     "html": "<p>[foo<code>][ref]</code></p>\n",
     "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
     "section": "Links",
-    "start_line": 6896
-  },
-  {
-    "end_line": 6910,
-    "example": 491,
-    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
-    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
-    "section": "Links",
-    "start_line": 6904
-  },
-  {
-    "end_line": 6920,
-    "example": 492,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
-    "section": "Links",
-    "start_line": 6914
-  },
-  {
-    "end_line": 6930,
-    "example": 493,
-    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
-    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
-    "section": "Links",
-    "start_line": 6924
-  },
-  {
-    "end_line": 6942,
-    "example": 494,
-    "html": "<p><a href=\"/url\">Baz</a></p>\n",
-    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
-    "section": "Links",
-    "start_line": 6935
+    "start_line": 6938
   },
   {
     "end_line": 6952,
-    "example": 495,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "example": 493,
+    "html": "<p>[foo<a href=\"http://example.com/?search=%5D%5Bref%5D\">http://example.com/?search=][ref]</a></p>\n",
+    "markdown": "[foo<http://example.com/?search=][ref]>\n\n[ref]: /uri\n",
     "section": "Links",
     "start_line": 6946
   },
   {
-    "end_line": 6961,
-    "example": 496,
+    "end_line": 6962,
+    "example": 494,
     "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 6954
+    "start_line": 6956
   },
   {
-    "end_line": 6974,
-    "example": 497,
-    "html": "<p><a href=\"/url1\">bar</a></p>\n",
-    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "end_line": 6972,
+    "example": 495,
+    "html": "<p><a href=\"/url\">Толпой</a> is a Russian word.</p>\n",
+    "markdown": "[Толпой][Толпой] is a Russian word.\n\n[ТОЛПОЙ]: /url\n",
     "section": "Links",
     "start_line": 6966
   },
   {
-    "end_line": 6986,
+    "end_line": 6984,
+    "example": 496,
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "section": "Links",
+    "start_line": 6977
+  },
+  {
+    "end_line": 6994,
+    "example": 497,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 6988
+  },
+  {
+    "end_line": 7003,
     "example": 498,
-    "html": "<p>[bar][foo!]</p>\n",
-    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 6980
-  },
-  {
-    "end_line": 6998,
-    "example": 499,
-    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
-    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
-    "section": "Links",
-    "start_line": 6991
-  },
-  {
-    "end_line": 7007,
-    "example": 500,
-    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
-    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
-    "section": "Links",
-    "start_line": 7000
+    "start_line": 6996
   },
   {
     "end_line": 7016,
+    "example": 499,
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "section": "Links",
+    "start_line": 7008
+  },
+  {
+    "end_line": 7028,
+    "example": 500,
+    "html": "<p>[bar][foo!]</p>\n",
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "section": "Links",
+    "start_line": 7022
+  },
+  {
+    "end_line": 7040,
     "example": 501,
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "section": "Links",
+    "start_line": 7033
+  },
+  {
+    "end_line": 7049,
+    "example": 502,
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "section": "Links",
+    "start_line": 7042
+  },
+  {
+    "end_line": 7058,
+    "example": 503,
     "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
     "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
     "section": "Links",
-    "start_line": 7009
+    "start_line": 7051
   },
   {
-    "end_line": 7024,
-    "example": 502,
+    "end_line": 7066,
+    "example": 504,
     "html": "<p><a href=\"/uri\">foo</a></p>\n",
     "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
     "section": "Links",
-    "start_line": 7018
+    "start_line": 7060
   },
   {
-    "end_line": 7035,
-    "example": 503,
+    "end_line": 7077,
+    "example": 505,
     "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
     "markdown": "[]\n\n[]: /uri\n",
     "section": "Links",
-    "start_line": 7028
+    "start_line": 7070
   },
   {
-    "end_line": 7048,
-    "example": 504,
+    "end_line": 7090,
+    "example": 506,
     "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
     "markdown": "[\n ]\n\n[\n ]: /uri\n",
     "section": "Links",
-    "start_line": 7037
+    "start_line": 7079
   },
   {
-    "end_line": 7065,
-    "example": 505,
+    "end_line": 7107,
+    "example": 507,
     "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 7059
+    "start_line": 7101
   },
   {
-    "end_line": 7073,
-    "example": 506,
+    "end_line": 7115,
+    "example": 508,
     "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
     "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 7067
+    "start_line": 7109
   },
   {
-    "end_line": 7083,
-    "example": 507,
+    "end_line": 7125,
+    "example": 509,
     "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
     "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 7077
+    "start_line": 7119
   },
   {
-    "end_line": 7096,
-    "example": 508,
+    "end_line": 7138,
+    "example": 510,
     "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
     "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
-    "section": "Links",
-    "start_line": 7089
-  },
-  {
-    "end_line": 7113,
-    "example": 509,
-    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
-    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
-    "section": "Links",
-    "start_line": 7107
-  },
-  {
-    "end_line": 7121,
-    "example": 510,
-    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
-    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
-    "section": "Links",
-    "start_line": 7115
-  },
-  {
-    "end_line": 7129,
-    "example": 511,
-    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
-    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
-    "section": "Links",
-    "start_line": 7123
-  },
-  {
-    "end_line": 7137,
-    "example": 512,
-    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
-    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
     "section": "Links",
     "start_line": 7131
   },
   {
-    "end_line": 7147,
+    "end_line": 7155,
+    "example": 511,
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7149
+  },
+  {
+    "end_line": 7163,
+    "example": 512,
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7157
+  },
+  {
+    "end_line": 7171,
     "example": 513,
-    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
-    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
     "section": "Links",
-    "start_line": 7141
-  },
-  {
-    "end_line": 7157,
-    "example": 514,
-    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
-    "markdown": "[foo] bar\n\n[foo]: /url\n",
-    "section": "Links",
-    "start_line": 7151
-  },
-  {
-    "end_line": 7168,
-    "example": 515,
-    "html": "<p>[foo]</p>\n",
-    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
-    "section": "Links",
-    "start_line": 7162
+    "start_line": 7165
   },
   {
     "end_line": 7179,
-    "example": 516,
-    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
-    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "example": 514,
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
     "section": "Links",
     "start_line": 7173
   },
   {
-    "end_line": 7190,
-    "example": 517,
-    "html": "<p><a href=\"/url2\">foo</a></p>\n",
-    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "end_line": 7189,
+    "example": 515,
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
     "section": "Links",
     "start_line": 7183
   },
   {
-    "end_line": 7201,
+    "end_line": 7199,
+    "example": 516,
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "section": "Links",
+    "start_line": 7193
+  },
+  {
+    "end_line": 7210,
+    "example": 517,
+    "html": "<p>[foo]</p>\n",
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "section": "Links",
+    "start_line": 7204
+  },
+  {
+    "end_line": 7221,
     "example": 518,
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "section": "Links",
+    "start_line": 7215
+  },
+  {
+    "end_line": 7232,
+    "example": 519,
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "section": "Links",
+    "start_line": 7225
+  },
+  {
+    "end_line": 7243,
+    "example": 520,
     "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
     "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
     "section": "Links",
-    "start_line": 7195
+    "start_line": 7237
   },
   {
-    "end_line": 7213,
-    "example": 519,
+    "end_line": 7255,
+    "example": 521,
     "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
     "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
     "section": "Links",
-    "start_line": 7206
+    "start_line": 7248
   },
   {
-    "end_line": 7225,
-    "example": 520,
+    "end_line": 7267,
+    "example": 522,
     "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
     "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
     "section": "Links",
-    "start_line": 7218
-  },
-  {
-    "end_line": 7244,
-    "example": 521,
-    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
-    "markdown": "![foo](/url \"title\")\n",
-    "section": "Images",
-    "start_line": 7240
-  },
-  {
-    "end_line": 7252,
-    "example": 522,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
-    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
-    "section": "Images",
-    "start_line": 7246
-  },
-  {
-    "end_line": 7258,
-    "example": 523,
-    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
-    "markdown": "![foo ![bar](/url)](/url2)\n",
-    "section": "Images",
-    "start_line": 7254
-  },
-  {
-    "end_line": 7264,
-    "example": 524,
-    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
-    "markdown": "![foo [bar](/url)](/url2)\n",
-    "section": "Images",
     "start_line": 7260
   },
   {
-    "end_line": 7279,
+    "end_line": 7286,
+    "example": 523,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo](/url \"title\")\n",
+    "section": "Images",
+    "start_line": 7282
+  },
+  {
+    "end_line": 7294,
+    "example": 524,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "section": "Images",
+    "start_line": 7288
+  },
+  {
+    "end_line": 7300,
     "example": 525,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
-    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "markdown": "![foo ![bar](/url)](/url2)\n",
     "section": "Images",
-    "start_line": 7273
+    "start_line": 7296
   },
   {
-    "end_line": 7287,
+    "end_line": 7306,
     "example": 526,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
-    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "markdown": "![foo [bar](/url)](/url2)\n",
     "section": "Images",
-    "start_line": 7281
-  },
-  {
-    "end_line": 7293,
-    "example": 527,
-    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo](train.jpg)\n",
-    "section": "Images",
-    "start_line": 7289
-  },
-  {
-    "end_line": 7299,
-    "example": 528,
-    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
-    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
-    "section": "Images",
-    "start_line": 7295
-  },
-  {
-    "end_line": 7305,
-    "example": 529,
-    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo](<url>)\n",
-    "section": "Images",
-    "start_line": 7301
-  },
-  {
-    "end_line": 7311,
-    "example": 530,
-    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
-    "markdown": "![](/url)\n",
-    "section": "Images",
-    "start_line": 7307
+    "start_line": 7302
   },
   {
     "end_line": 7321,
-    "example": 531,
-    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "example": 527,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
     "section": "Images",
     "start_line": 7315
   },
   {
     "end_line": 7329,
-    "example": 532,
-    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
-    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "example": 528,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
     "section": "Images",
     "start_line": 7323
   },
   {
-    "end_line": 7339,
-    "example": 533,
-    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
-    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "end_line": 7335,
+    "example": 529,
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo](train.jpg)\n",
     "section": "Images",
-    "start_line": 7333
+    "start_line": 7331
+  },
+  {
+    "end_line": 7341,
+    "example": 530,
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "section": "Images",
+    "start_line": 7337
   },
   {
     "end_line": 7347,
+    "example": 531,
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo](<url>)\n",
+    "section": "Images",
+    "start_line": 7343
+  },
+  {
+    "end_line": 7353,
+    "example": 532,
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "markdown": "![](/url)\n",
+    "section": "Images",
+    "start_line": 7349
+  },
+  {
+    "end_line": 7363,
+    "example": 533,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo] [bar]\n\n[bar]: /url\n",
+    "section": "Images",
+    "start_line": 7357
+  },
+  {
+    "end_line": 7371,
     "example": 534,
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "markdown": "![foo] [bar]\n\n[BAR]: /url\n",
+    "section": "Images",
+    "start_line": 7365
+  },
+  {
+    "end_line": 7381,
+    "example": 535,
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "section": "Images",
+    "start_line": 7375
+  },
+  {
+    "end_line": 7389,
+    "example": 536,
     "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
     "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7341
+    "start_line": 7383
   },
   {
-    "end_line": 7357,
-    "example": 535,
+    "end_line": 7399,
+    "example": 537,
     "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
     "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7351
+    "start_line": 7393
   },
   {
-    "end_line": 7369,
-    "example": 536,
+    "end_line": 7411,
+    "example": 538,
     "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
     "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7362
+    "start_line": 7404
   },
   {
-    "end_line": 7379,
-    "example": 537,
+    "end_line": 7421,
+    "example": 539,
     "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
     "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7373
+    "start_line": 7415
   },
   {
-    "end_line": 7387,
-    "example": 538,
+    "end_line": 7429,
+    "example": 540,
     "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
     "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7381
+    "start_line": 7423
   },
   {
-    "end_line": 7398,
-    "example": 539,
+    "end_line": 7440,
+    "example": 541,
     "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
     "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7391
+    "start_line": 7433
   },
   {
-    "end_line": 7408,
-    "example": 540,
+    "end_line": 7450,
+    "example": 542,
     "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
     "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7402
+    "start_line": 7444
   },
   {
-    "end_line": 7419,
-    "example": 541,
+    "end_line": 7461,
+    "example": 543,
     "html": "<p>![foo]</p>\n",
     "markdown": "\\!\\[foo]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7413
+    "start_line": 7455
   },
   {
-    "end_line": 7430,
-    "example": 542,
+    "end_line": 7472,
+    "example": 544,
     "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
     "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
     "section": "Images",
-    "start_line": 7424
+    "start_line": 7466
   },
   {
-    "end_line": 7481,
-    "example": 543,
+    "end_line": 7523,
+    "example": 545,
     "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
     "markdown": "<http://foo.bar.baz>\n",
     "section": "Autolinks",
-    "start_line": 7477
+    "start_line": 7519
   },
   {
-    "end_line": 7487,
-    "example": 544,
+    "end_line": 7529,
+    "example": 546,
     "html": "<p><a href=\"http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
     "markdown": "<http://foo.bar.baz/test?q=hello&id=22&boolean>\n",
     "section": "Autolinks",
-    "start_line": 7483
+    "start_line": 7525
   },
   {
-    "end_line": 7493,
-    "example": 545,
+    "end_line": 7535,
+    "example": 547,
     "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
     "markdown": "<irc://foo.bar:2233/baz>\n",
     "section": "Autolinks",
-    "start_line": 7489
+    "start_line": 7531
   },
   {
-    "end_line": 7501,
-    "example": 546,
+    "end_line": 7543,
+    "example": 548,
     "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
     "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
     "section": "Autolinks",
-    "start_line": 7497
+    "start_line": 7539
   },
   {
-    "end_line": 7509,
-    "example": 547,
+    "end_line": 7551,
+    "example": 549,
     "html": "<p>&lt;http://foo.bar/baz bim&gt;</p>\n",
     "markdown": "<http://foo.bar/baz bim>\n",
     "section": "Autolinks",
-    "start_line": 7505
+    "start_line": 7547
   },
   {
-    "end_line": 7517,
-    "example": 548,
+    "end_line": 7559,
+    "example": 550,
     "html": "<p><a href=\"http://example.com/%5C%5B%5C\">http://example.com/\\[\\</a></p>\n",
     "markdown": "<http://example.com/\\[\\>\n",
     "section": "Autolinks",
-    "start_line": 7513
+    "start_line": 7555
   },
   {
-    "end_line": 7538,
-    "example": 549,
+    "end_line": 7580,
+    "example": 551,
     "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
     "markdown": "<foo@bar.example.com>\n",
     "section": "Autolinks",
-    "start_line": 7534
+    "start_line": 7576
   },
   {
-    "end_line": 7544,
-    "example": 550,
+    "end_line": 7586,
+    "example": 552,
     "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
     "markdown": "<foo+special@Bar.baz-bar0.com>\n",
     "section": "Autolinks",
-    "start_line": 7540
+    "start_line": 7582
   },
   {
-    "end_line": 7552,
-    "example": 551,
+    "end_line": 7594,
+    "example": 553,
     "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
     "markdown": "<foo\\+@bar.example.com>\n",
     "section": "Autolinks",
-    "start_line": 7548
+    "start_line": 7590
   },
   {
-    "end_line": 7560,
-    "example": 552,
+    "end_line": 7602,
+    "example": 554,
     "html": "<p>&lt;&gt;</p>\n",
     "markdown": "<>\n",
     "section": "Autolinks",
-    "start_line": 7556
+    "start_line": 7598
   },
   {
-    "end_line": 7566,
-    "example": 553,
+    "end_line": 7608,
+    "example": 555,
     "html": "<p>&lt;heck://bing.bong&gt;</p>\n",
     "markdown": "<heck://bing.bong>\n",
     "section": "Autolinks",
-    "start_line": 7562
+    "start_line": 7604
   },
   {
-    "end_line": 7572,
-    "example": 554,
+    "end_line": 7614,
+    "example": 556,
     "html": "<p>&lt; http://foo.bar &gt;</p>\n",
     "markdown": "< http://foo.bar >\n",
     "section": "Autolinks",
-    "start_line": 7568
+    "start_line": 7610
   },
   {
-    "end_line": 7578,
-    "example": 555,
+    "end_line": 7620,
+    "example": 557,
     "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
     "markdown": "<foo.bar.baz>\n",
     "section": "Autolinks",
-    "start_line": 7574
+    "start_line": 7616
   },
   {
-    "end_line": 7584,
-    "example": 556,
+    "end_line": 7626,
+    "example": 558,
     "html": "<p>&lt;localhost:5001/foo&gt;</p>\n",
     "markdown": "<localhost:5001/foo>\n",
     "section": "Autolinks",
-    "start_line": 7580
+    "start_line": 7622
   },
   {
-    "end_line": 7590,
-    "example": 557,
+    "end_line": 7632,
+    "example": 559,
     "html": "<p>http://example.com</p>\n",
     "markdown": "http://example.com\n",
     "section": "Autolinks",
-    "start_line": 7586
+    "start_line": 7628
   },
   {
-    "end_line": 7596,
-    "example": 558,
+    "end_line": 7638,
+    "example": 560,
     "html": "<p>foo@bar.example.com</p>\n",
     "markdown": "foo@bar.example.com\n",
     "section": "Autolinks",
-    "start_line": 7592
+    "start_line": 7634
   },
   {
-    "end_line": 7677,
-    "example": 559,
+    "end_line": 7719,
+    "example": 561,
     "html": "<p><a><bab><c2c></p>\n",
     "markdown": "<a><bab><c2c>\n",
     "section": "Raw HTML",
-    "start_line": 7673
+    "start_line": 7715
   },
   {
-    "end_line": 7685,
-    "example": 560,
+    "end_line": 7727,
+    "example": 562,
     "html": "<p><a/><b2/></p>\n",
     "markdown": "<a/><b2/>\n",
     "section": "Raw HTML",
-    "start_line": 7681
+    "start_line": 7723
   },
   {
-    "end_line": 7695,
-    "example": 561,
+    "end_line": 7737,
+    "example": 563,
     "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
     "markdown": "<a  /><b2\ndata=\"foo\" >\n",
     "section": "Raw HTML",
-    "start_line": 7689
+    "start_line": 7731
   },
   {
-    "end_line": 7705,
-    "example": 562,
+    "end_line": 7747,
+    "example": 564,
     "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
     "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
     "section": "Raw HTML",
-    "start_line": 7699
-  },
-  {
-    "end_line": 7720,
-    "example": 563,
-    "html": "<responsive-image src=\"foo.jpg\" />\n<My-Tag>\nfoo\n</My-Tag>\n",
-    "markdown": "<responsive-image src=\"foo.jpg\" />\n\n<My-Tag>\nfoo\n</My-Tag>\n",
-    "section": "Raw HTML",
-    "start_line": 7709
-  },
-  {
-    "end_line": 7728,
-    "example": 564,
-    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
-    "markdown": "<33> <__>\n",
-    "section": "Raw HTML",
-    "start_line": 7724
-  },
-  {
-    "end_line": 7736,
-    "example": 565,
-    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
-    "markdown": "<a h*#ref=\"hi\">\n",
-    "section": "Raw HTML",
-    "start_line": 7732
-  },
-  {
-    "end_line": 7744,
-    "example": 566,
-    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
-    "markdown": "<a href=\"hi'> <a href=hi'>\n",
-    "section": "Raw HTML",
-    "start_line": 7740
-  },
-  {
-    "end_line": 7754,
-    "example": 567,
-    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
-    "markdown": "< a><\nfoo><bar/ >\n",
-    "section": "Raw HTML",
-    "start_line": 7748
+    "start_line": 7741
   },
   {
     "end_line": 7762,
-    "example": 568,
-    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
-    "markdown": "<a href='bar'title=title>\n",
+    "example": 565,
+    "html": "<responsive-image src=\"foo.jpg\" />\n<My-Tag>\nfoo\n</My-Tag>\n",
+    "markdown": "<responsive-image src=\"foo.jpg\" />\n\n<My-Tag>\nfoo\n</My-Tag>\n",
     "section": "Raw HTML",
-    "start_line": 7758
+    "start_line": 7751
   },
   {
-    "end_line": 7772,
-    "example": 569,
-    "html": "</a>\n</foo >\n",
-    "markdown": "</a>\n</foo >\n",
+    "end_line": 7770,
+    "example": 566,
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "markdown": "<33> <__>\n",
     "section": "Raw HTML",
     "start_line": 7766
   },
   {
-    "end_line": 7780,
-    "example": 570,
-    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
-    "markdown": "</a href=\"foo\">\n",
+    "end_line": 7778,
+    "example": 567,
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "markdown": "<a h*#ref=\"hi\">\n",
     "section": "Raw HTML",
-    "start_line": 7776
+    "start_line": 7774
   },
   {
-    "end_line": 7790,
-    "example": 571,
-    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
-    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "end_line": 7786,
+    "example": 568,
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
     "section": "Raw HTML",
-    "start_line": 7784
+    "start_line": 7782
   },
   {
     "end_line": 7796,
-    "example": 572,
-    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
-    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "example": 569,
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;</p>\n",
+    "markdown": "< a><\nfoo><bar/ >\n",
     "section": "Raw HTML",
-    "start_line": 7792
+    "start_line": 7790
   },
   {
-    "end_line": 7807,
-    "example": 573,
-    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
-    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "end_line": 7804,
+    "example": 570,
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "markdown": "<a href='bar'title=title>\n",
     "section": "Raw HTML",
     "start_line": 7800
   },
   {
-    "end_line": 7815,
+    "end_line": 7814,
+    "example": 571,
+    "html": "</a>\n</foo >\n",
+    "markdown": "</a>\n</foo >\n",
+    "section": "Raw HTML",
+    "start_line": 7808
+  },
+  {
+    "end_line": 7822,
+    "example": 572,
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "markdown": "</a href=\"foo\">\n",
+    "section": "Raw HTML",
+    "start_line": 7818
+  },
+  {
+    "end_line": 7832,
+    "example": 573,
+    "html": "<p>foo <!-- this is a\ncomment - with hyphen --></p>\n",
+    "markdown": "foo <!-- this is a\ncomment - with hyphen -->\n",
+    "section": "Raw HTML",
+    "start_line": 7826
+  },
+  {
+    "end_line": 7838,
     "example": 574,
+    "html": "<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>\n",
+    "markdown": "foo <!-- not a comment -- two hyphens -->\n",
+    "section": "Raw HTML",
+    "start_line": 7834
+  },
+  {
+    "end_line": 7849,
+    "example": 575,
+    "html": "<p>foo &lt;!--&gt; foo --&gt;</p>\n<p>foo &lt;!-- foo---&gt;</p>\n",
+    "markdown": "foo <!--> foo -->\n\nfoo <!-- foo--->\n",
+    "section": "Raw HTML",
+    "start_line": 7842
+  },
+  {
+    "end_line": 7857,
+    "example": 576,
     "html": "<p>foo <?php echo $a; ?></p>\n",
     "markdown": "foo <?php echo $a; ?>\n",
     "section": "Raw HTML",
-    "start_line": 7811
+    "start_line": 7853
   },
   {
-    "end_line": 7823,
-    "example": 575,
+    "end_line": 7865,
+    "example": 577,
     "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
     "markdown": "foo <!ELEMENT br EMPTY>\n",
     "section": "Raw HTML",
-    "start_line": 7819
+    "start_line": 7861
   },
   {
-    "end_line": 7831,
-    "example": 576,
+    "end_line": 7873,
+    "example": 578,
     "html": "<p>foo <![CDATA[>&<]]></p>\n",
     "markdown": "foo <![CDATA[>&<]]>\n",
     "section": "Raw HTML",
-    "start_line": 7827
+    "start_line": 7869
   },
   {
-    "end_line": 7839,
-    "example": 577,
+    "end_line": 7881,
+    "example": 579,
     "html": "<a href=\"&ouml;\">\n",
     "markdown": "<a href=\"&ouml;\">\n",
     "section": "Raw HTML",
-    "start_line": 7835
-  },
-  {
-    "end_line": 7847,
-    "example": 578,
-    "html": "<a href=\"\\*\">\n",
-    "markdown": "<a href=\"\\*\">\n",
-    "section": "Raw HTML",
-    "start_line": 7843
-  },
-  {
-    "end_line": 7853,
-    "example": 579,
-    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
-    "markdown": "<a href=\"\\\"\">\n",
-    "section": "Raw HTML",
-    "start_line": 7849
-  },
-  {
-    "end_line": 7868,
-    "example": 580,
-    "html": "<p>foo<br />\nbaz</p>\n",
-    "markdown": "foo  \nbaz\n",
-    "section": "Hard line breaks",
-    "start_line": 7862
-  },
-  {
-    "end_line": 7879,
-    "example": 581,
-    "html": "<p>foo<br />\nbaz</p>\n",
-    "markdown": "foo\\\nbaz\n",
-    "section": "Hard line breaks",
-    "start_line": 7873
+    "start_line": 7877
   },
   {
     "end_line": 7889,
+    "example": 580,
+    "html": "<a href=\"\\*\">\n",
+    "markdown": "<a href=\"\\*\">\n",
+    "section": "Raw HTML",
+    "start_line": 7885
+  },
+  {
+    "end_line": 7895,
+    "example": 581,
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "markdown": "<a href=\"\\\"\">\n",
+    "section": "Raw HTML",
+    "start_line": 7891
+  },
+  {
+    "end_line": 7910,
     "example": 582,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo  \nbaz\n",
+    "section": "Hard line breaks",
+    "start_line": 7904
+  },
+  {
+    "end_line": 7921,
+    "example": 583,
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "markdown": "foo\\\nbaz\n",
+    "section": "Hard line breaks",
+    "start_line": 7915
+  },
+  {
+    "end_line": 7931,
+    "example": 584,
     "html": "<p>foo<br />\nbaz</p>\n",
     "markdown": "foo       \nbaz\n",
     "section": "Hard line breaks",
-    "start_line": 7883
+    "start_line": 7925
   },
   {
-    "end_line": 7899,
-    "example": 583,
+    "end_line": 7941,
+    "example": 585,
     "html": "<p>foo<br />\nbar</p>\n",
     "markdown": "foo  \n     bar\n",
     "section": "Hard line breaks",
-    "start_line": 7893
+    "start_line": 7935
   },
   {
-    "end_line": 7907,
-    "example": 584,
+    "end_line": 7949,
+    "example": 586,
     "html": "<p>foo<br />\nbar</p>\n",
     "markdown": "foo\\\n     bar\n",
     "section": "Hard line breaks",
-    "start_line": 7901
-  },
-  {
-    "end_line": 7918,
-    "example": 585,
-    "html": "<p><em>foo<br />\nbar</em></p>\n",
-    "markdown": "*foo  \nbar*\n",
-    "section": "Hard line breaks",
-    "start_line": 7912
-  },
-  {
-    "end_line": 7926,
-    "example": 586,
-    "html": "<p><em>foo<br />\nbar</em></p>\n",
-    "markdown": "*foo\\\nbar*\n",
-    "section": "Hard line breaks",
-    "start_line": 7920
-  },
-  {
-    "end_line": 7935,
-    "example": 587,
-    "html": "<p><code>code span</code></p>\n",
-    "markdown": "`code  \nspan`\n",
-    "section": "Hard line breaks",
-    "start_line": 7930
-  },
-  {
-    "end_line": 7942,
-    "example": 588,
-    "html": "<p><code>code\\ span</code></p>\n",
-    "markdown": "`code\\\nspan`\n",
-    "section": "Hard line breaks",
-    "start_line": 7937
-  },
-  {
-    "end_line": 7952,
-    "example": 589,
-    "html": "<p><a href=\"foo  \nbar\"></p>\n",
-    "markdown": "<a href=\"foo  \nbar\">\n",
-    "section": "Hard line breaks",
-    "start_line": 7946
+    "start_line": 7943
   },
   {
     "end_line": 7960,
-    "example": 590,
-    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
-    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "example": 587,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "markdown": "*foo  \nbar*\n",
     "section": "Hard line breaks",
     "start_line": 7954
   },
   {
-    "end_line": 7970,
-    "example": 591,
-    "html": "<p>foo\\</p>\n",
-    "markdown": "foo\\\n",
+    "end_line": 7968,
+    "example": 588,
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "markdown": "*foo\\\nbar*\n",
     "section": "Hard line breaks",
-    "start_line": 7966
+    "start_line": 7962
   },
   {
-    "end_line": 7976,
-    "example": 592,
-    "html": "<p>foo</p>\n",
-    "markdown": "foo  \n",
+    "end_line": 7977,
+    "example": 589,
+    "html": "<p><code>code span</code></p>\n",
+    "markdown": "`code  \nspan`\n",
     "section": "Hard line breaks",
     "start_line": 7972
   },
   {
-    "end_line": 7982,
+    "end_line": 7984,
+    "example": 590,
+    "html": "<p><code>code\\ span</code></p>\n",
+    "markdown": "`code\\\nspan`\n",
+    "section": "Hard line breaks",
+    "start_line": 7979
+  },
+  {
+    "end_line": 7994,
+    "example": 591,
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "section": "Hard line breaks",
+    "start_line": 7988
+  },
+  {
+    "end_line": 8002,
+    "example": 592,
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "section": "Hard line breaks",
+    "start_line": 7996
+  },
+  {
+    "end_line": 8012,
     "example": 593,
+    "html": "<p>foo\\</p>\n",
+    "markdown": "foo\\\n",
+    "section": "Hard line breaks",
+    "start_line": 8008
+  },
+  {
+    "end_line": 8018,
+    "example": 594,
+    "html": "<p>foo</p>\n",
+    "markdown": "foo  \n",
+    "section": "Hard line breaks",
+    "start_line": 8014
+  },
+  {
+    "end_line": 8024,
+    "example": 595,
     "html": "<h3>foo\\</h3>\n",
     "markdown": "### foo\\\n",
     "section": "Hard line breaks",
-    "start_line": 7978
+    "start_line": 8020
   },
   {
-    "end_line": 7988,
-    "example": 594,
+    "end_line": 8030,
+    "example": 596,
     "html": "<h3>foo</h3>\n",
     "markdown": "### foo  \n",
     "section": "Hard line breaks",
-    "start_line": 7984
-  },
-  {
-    "end_line": 8004,
-    "example": 595,
-    "html": "<p>foo\nbaz</p>\n",
-    "markdown": "foo\nbaz\n",
-    "section": "Soft line breaks",
-    "start_line": 7998
-  },
-  {
-    "end_line": 8015,
-    "example": 596,
-    "html": "<p>foo\nbaz</p>\n",
-    "markdown": "foo \n baz\n",
-    "section": "Soft line breaks",
-    "start_line": 8009
-  },
-  {
-    "end_line": 8032,
-    "example": 597,
-    "html": "<p>hello $.;'there</p>\n",
-    "markdown": "hello $.;'there\n",
-    "section": "Textual content",
-    "start_line": 8028
-  },
-  {
-    "end_line": 8038,
-    "example": 598,
-    "html": "<p>Foo χρῆν</p>\n",
-    "markdown": "Foo χρῆν\n",
-    "section": "Textual content",
-    "start_line": 8034
+    "start_line": 8026
   },
   {
     "end_line": 8046,
+    "example": 597,
+    "html": "<p>foo\nbaz</p>\n",
+    "markdown": "foo\nbaz\n",
+    "section": "Soft line breaks",
+    "start_line": 8040
+  },
+  {
+    "end_line": 8057,
+    "example": 598,
+    "html": "<p>foo\nbaz</p>\n",
+    "markdown": "foo \n baz\n",
+    "section": "Soft line breaks",
+    "start_line": 8051
+  },
+  {
+    "end_line": 8074,
     "example": 599,
+    "html": "<p>hello $.;'there</p>\n",
+    "markdown": "hello $.;'there\n",
+    "section": "Textual content",
+    "start_line": 8070
+  },
+  {
+    "end_line": 8080,
+    "example": 600,
+    "html": "<p>Foo χρῆν</p>\n",
+    "markdown": "Foo χρῆν\n",
+    "section": "Textual content",
+    "start_line": 8076
+  },
+  {
+    "end_line": 8088,
+    "example": 601,
     "html": "<p>Multiple     spaces</p>\n",
     "markdown": "Multiple     spaces\n",
     "section": "Textual content",
-    "start_line": 8042
+    "start_line": 8084
   }
 ]

--- a/test/cmark_test.exs
+++ b/test/cmark_test.exs
@@ -5,13 +5,38 @@ defmodule CmarkTest do
   @cmark_specs File.read!("test/cmark_specs.json") |> Poison.decode!(keys: :atoms)
 
   for %{
-        section: section, example: example,
-        markdown: markdown, html: html,
-        start_line: start_line, end_line: end_line
+        section: section,
+        example: example,
+        markdown: markdown,
+        html: html,
+        start_line: start_line,
+        end_line: end_line
       } <- @cmark_specs do
     test "Section: »#{section}«, Example: #{example}, Lines: #{start_line}-#{end_line}" do
       real_markdown = unquote(markdown)
       actual_html   = Cmark.to_html(real_markdown)
+      expected_html = unquote(html)
+      error_message = """
+      MARKDOWN: #{inspect real_markdown}
+      ACTUAL:   #{inspect actual_html}
+      EXPECTED: #{inspect expected_html}
+      """
+      assert actual_html == expected_html, error_message
+    end
+  end
+
+  @cmark_smart_punct File.read!("test/cmark_smart_punct.json") |> Poison.decode!(keys: :atoms)
+  for %{
+        section: section,
+        example: example,
+        markdown: markdown,
+        html: html,
+        start_line: start_line,
+        end_line: end_line
+      } <- @cmark_smart_punct do
+    test "Section: »#{section}«, Example: #{example}, Lines: #{start_line}-#{end_line}" do
+      real_markdown = unquote(markdown)
+      actual_html   = Cmark.to_html(real_markdown, [ :smart ])
       expected_html = unquote(html)
       error_message = """
       MARKDOWN: #{inspect real_markdown}


### PR DESCRIPTION
This adds support for the [CMARK_OPT_*][1] flags.

The flags are defined as:

* `default`: No options, provided to align with the cmark source.
  Passing `default: true` does nothing, and any other flags will
  override it due to how the option value is calculated (bitwise).
* `sourcepos`: Include a `data-sourcepos` attribute on all block elements
* `hardbreaks`: Render `softbreak` elements as hard line breaks
* `safe`: Suppress raw HTML and unsafe links (`javascript:`, `vbscript:`,
  `file:`, and `data:`, except for `image/png`, `image/gif`,
  `image/jpeg`, or `image/webp` mime types).  Raw HTML is replaced
  by a placeholder HTML comment. Unsafe links are replaced by
  empty strings.
* `normalize`: Normalize tree by consolidating adjacent text nodes.
* `validate_utf8`: Validate UTF-8 in the input before parsing, replacing
  illegal sequences with the replacement character U+FFFD.
* `smart`: Convert straight quotes to curly, --- to em dashes, -- to en dashes.

Options are enabled by passing a list to `to_html/2` or `to_html/3`,
e.g.:

```elixir
Cmark.to_html(some_markdown_string, [smart: true, sourcepos: true])
```

TODO:
- [x] Review C code, because I have no idea.
- [x] Update exdoc/README as appropriate.
- [x] ~~Is passing a list of booleans with true/false appropriate or
  should it just be a list of symbols? E.g. `[smart: true, sourcepos:
  true]` vs just `[:smart, :sourcepos]`.~~ Rewrite params as keyword, list, e.g. `[:smart, :sourcepos]`
- [x] ~~Should `@flags` be a module attribute or just a map in the method?~~ Move `@flags` into method
- [x] Review method of parsing/calculating bitwise options value.
- [x] Review function signatures/definitions, seems kind of messy.
- [x] Write some more specific tests.  The tests generated from cmark don't
  exercise any of the option flags beyond `smart`.

[1]: https://github.com/jgm/cmark/blob/0.22.0/src/cmark.h#L450-L481