### PR TITLE
Add support for latex, xml, man and commonmark conversions.

### DIFF
--- a/lib/cmark.ex
+++ b/lib/cmark.ex
@@ -4,10 +4,26 @@ defmodule Cmark do
 
   Provides:
 
+  * `to_commonmark/1`
+  * `to_commonmark/2`
+  * `to_commonmark/3`
+  * `to_commonmark_each/3`
   * `to_html/1`
   * `to_html/2`
   * `to_html/3`
   * `to_html_each/3`
+  * `to_latex/1`
+  * `to_latex/2`
+  * `to_latex/3`
+  * `to_latex_each/3`
+  * `to_man/1`
+  * `to_man/2`
+  * `to_man/3`
+  * `to_man_each/3`
+  * `to_xml/1`
+  * `to_xml/2`
+  * `to_xml/3`
+  * `to_xml_each/3`
 
   """
 
@@ -21,27 +37,63 @@ defmodule Cmark do
     smart: 1024,         # (1 <<< 10)
   }
 
-  @doc """
+  # FIXME: Defining the indexes in two palces (here and in C) is terrible.
+  # Either pass a string to the C (ew) expose a C function that returns the
+  # integer a format corresponds to (also ew)...?
+  # Maybe just pass an atom to C.
+  @formats [
+    html: 1,
+    xml: 2,
+    man: 3,
+    commonmark: 4,
+    latex: 5
+  ]
+
+  @doc ~S"""
   Compiles one or more (list) Markdown documents to HTML and returns result.
 
   ## Examples
 
       iex> "test" |> Cmark.to_html
-      "<p>test</p>\\n"
+      "<p>test</p>\n"
 
       iex> ["# also works", "* with list", "`of documents`"] |> Cmark.to_html
-      ["<h1>also works</h1>\\n",
-      "<ul>\\n<li>with list</li>\\n</ul>\\n",
-      "<p><code>of documents</code></p>\\n"]
+      ["<h1>also works</h1>\n",
+      "<ul>\n<li>with list</li>\n</ul>\n",
+      "<p><code>of documents</code></p>\n"]
+
+
+      iex> markdown = ~s(
+      ...> # Lorem Ipsum Dolor Sit Amet
+      ...>
+      ...> Consectetur adipiscing elit. Integer pulvinar ipsum a ante ornare dignissim. Nulla vel lacus feugiat, volutpat risus eget, semper nisl.
+      ...>
+      ...> 1. Quisque varius nisi
+      ...> 2. Quisque ac sem ac lacus
+      ...>
+      ...>)
+      iex> Cmark.to_commonmark(markdown)
+      "# Lorem Ipsum Dolor Sit Amet\n\nConsectetur adipiscing elit. Integer pulvinar ipsum a ante ornare dignissim. Nulla vel lacus feugiat, volutpat risus eget, semper nisl.\n\n1.  Quisque varius nisi\n2.  Quisque ac sem ac lacus\n"
+      iex> Cmark.to_html(markdown)
+      "<h1>Lorem Ipsum Dolor Sit Amet</h1>\n<p>Consectetur adipiscing elit. Integer pulvinar ipsum a ante ornare dignissim. Nulla vel lacus feugiat, volutpat risus eget, semper nisl.</p>\n<ol>\n<li>Quisque varius nisi</li>\n<li>Quisque ac sem ac lacus</li>\n</ol>\n"
+      iex> Cmark.to_xml(markdown)
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <heading level=\"1\">\n    <text>Lorem Ipsum Dolor Sit Amet</text>\n  </heading>\n  <paragraph>\n    <text>Consectetur adipiscing elit. Integer pulvinar ipsum a ante ornare dignissim. Nulla vel lacus feugiat, volutpat risus eget, semper nisl.</text>\n  </paragraph>\n  <list type=\"ordered\" start=\"1\" delim=\"period\" tight=\"true\">\n    <item>\n      <paragraph>\n        <text>Quisque varius nisi</text>\n      </paragraph>\n    </item>\n    <item>\n      <paragraph>\n        <text>Quisque ac sem ac lacus</text>\n      </paragraph>\n    </item>\n  </list>\n</document>\n"
+      iex> Cmark.to_latex(markdown)
+      "\\section{Lorem Ipsum Dolor Sit Amet}\n\nConsectetur adipiscing elit. Integer pulvinar ipsum a ante ornare dignissim. Nulla vel lacus feugiat, volutpat risus eget, semper nisl.\n\n\\begin{enumerate}\n\\item Quisque varius nisi\n\n\\item Quisque ac sem ac lacus\n\n\\end{enumerate}\n"
+      iex> Cmark.to_man(markdown)
+      ".SH\nLorem Ipsum Dolor Sit Amet\n.PP\nConsectetur adipiscing elit. Integer pulvinar ipsum a ante ornare dignissim. Nulla vel lacus feugiat, volutpat risus eget, semper nisl.\n.IP \"1.\" 4\nQuisque varius nisi\n.IP \"2.\" 4\nQuisque ac sem ac lacus\n"
 
   """
-  def to_html(data) when is_list(data) do
-    parse_doc_list(data, [])
-  end
+  @formats |> Enum.map(fn {format, _} ->
+    def unquote(:"to_#{format}")(data) when is_list(data) do
+      parse_doc_list(data, [], unquote(format))
+    end
 
-  def to_html(data) when is_bitstring(data) do
-    parse_doc(data, [])
-  end
+    def unquote(:"to_#{format}")(data) when is_bitstring(data) do
+      parse_doc(data, [], unquote(format))
+    end
+  end)
+
 
   @doc """
   Compiles one or more (list) Markdown documents to HTML using provided options
@@ -68,13 +120,15 @@ defmodule Cmark do
 
   """
 
-  def to_html(data, options) when is_list(data) and is_list(options) do
-    parse_doc_list(data, options)
-  end
+  @formats |> Enum.map(fn {format, _} ->
+    def unquote(:"to_#{format}")(data, options) when is_list(data) and is_list(options) do
+      parse_doc_list(data, options, unquote(format))
+    end
 
-  def to_html(data, options) when is_bitstring(data) and is_list(options) do
-    parse_doc(data, options)
-  end
+    def unquote(:"to_#{format}")(data, options) when is_bitstring(data) and is_list(options) do
+      parse_doc(data, options, unquote(format))
+    end
+  end)
 
   @doc """
   Compiles one or more (list) Markdown documents to HTML and calls function with result.
@@ -92,13 +146,16 @@ defmodule Cmark do
       "<p>list</p><hr><p>test</p>"
 
   """
-  def to_html(data, callback) when is_list(data) and is_function(callback) do
-    parse_doc_list(data, callback, [])
-  end
+  @formats |> Enum.map(fn {format, _} ->
+    def unquote(:"to_#{format}")(data, callback) when is_list(data) and is_function(callback) do
+      parse_doc_list(data, callback, [], unquote(format))
+    end
 
-  def to_html(data, callback) when is_bitstring(data) and is_function(callback) do
-    parse_doc(data, callback, [])
-  end
+    def unquote(:"to_#{format}")(data, callback) when is_bitstring(data) and is_function(callback) do
+      parse_doc(data, callback, [], unquote(format))
+    end
+  end)
+
 
   @doc """
   Compiles one or more (list) Markdown documents to HTML using provided options
@@ -113,13 +170,16 @@ defmodule Cmark do
       "<p>en-dash –</p><hr><p>ellipsis…</p>"
 
   """
-  def to_html(data, callback, options) when is_list(data) and is_function(callback) and is_list(options) do
-    parse_doc_list(data, callback, options)
-  end
+  @formats |> Enum.map(fn {format, _} ->
+    def unquote(:"to_#{format}")(data, callback, options) when is_list(data) and is_list(options) do
+      parse_doc_list(data, callback, options, unquote(format))
+    end
 
-  def to_html(data, callback, options) when is_bitstring(data) and is_function(callback) and is_list(options) do
-    parse_doc(data, callback, options)
-  end
+    def unquote(:"to_#{format}")(data, callback, options) when is_bitstring(data) and is_list(options) do
+      parse_doc(data, callback, options, unquote(format))
+    end
+  end)
+
 
   @doc """
   Compiles a list of Markdown documents using provided options and calls
@@ -132,39 +192,45 @@ defmodule Cmark do
       ["HTML is <p>list</p>", "HTML is <p>test</p>"]
 
   """
-  def to_html_each(data, callback, options \\ []) when is_list(data) do
-    parse_doc_list_each(data, callback, options)
+  @formats |> Enum.map(fn {format, _} ->
+   def unquote(:"to_#{format}_each")(data, callback, options \\ []) when is_list(data) do
+     parse_doc_list_each(data, callback, options, unquote(format))
+   end
+ end)
+
+
+  defp parse_doc_list(documents, callback, options, format) when is_function(callback) do
+    callback.(parse_doc_list(documents, options, format))
   end
 
-
-  defp parse_doc_list(documents, callback, options) when is_function(callback) do
-    callback.(parse_doc_list(documents, options))
-  end
-
-  defp parse_doc_list(documents, options) when is_list(options) do
+  defp parse_doc_list(documents, options, format) when is_list(options) do
     documents
-    |> Enum.map(&Task.async(fn -> parse_doc(&1, options) end))
+    |> Enum.map(&Task.async(fn -> parse_doc(&1, options, format) end))
     |> Enum.map(&Task.await(&1))
   end
 
 
-  defp parse_doc_list_each(documents, callback, options) do
+  defp parse_doc_list_each(documents, callback, options, format) do
     documents
-    |> Enum.map(&Task.async(fn -> parse_doc(&1, callback, options) end))
+    |> Enum.map(&Task.async(fn -> parse_doc(&1, callback, options, format) end))
     |> Enum.map(&Task.await(&1))
   end
 
 
-  defp parse_doc(document, callback, options) do
-    callback.(parse_doc(document, options))
+  defp parse_doc(document, callback, options, format) do
+    callback.(parse_doc(document, options, format))
   end
 
-  defp parse_doc(document, options) do
-    Cmark.Nif.to_html(document, parse_options(options))
+  defp parse_doc(document, options, format) do
+    Cmark.Nif.render(document, parse_options(options), parse_format(format))
   end
 
 
   defp parse_options(options) do
     Enum.reduce(options, 0, fn(flag, acc) -> @flags[flag] + acc end)
+  end
+
+  defp parse_format(format) do
+    @formats[format]
   end
 end

--- a/lib/cmark/nif.ex
+++ b/lib/cmark/nif.ex
@@ -26,7 +26,7 @@ defmodule Cmark.Nif do
   end
 
   @doc false
-  def to_html(_, _) do
+  def render(_, _, _) do
     exit(:nif_library_not_loaded)
   end
 end

--- a/src/cmark_nif.c
+++ b/src/cmark_nif.c
@@ -8,19 +8,45 @@
 #include "erl_nif.h"
 #include "cmark.h"
 
-static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+#define FORMAT_HTML 1
+#define FORMAT_XML 2
+#define FORMAT_MAN 3
+#define FORMAT_COMMONMARK 4
+#define FORMAT_LATEX 5
+
+/*
+ * Expose cmark parsers to Elixir via NIF
+ *
+ * Requires 3 arguments:
+ *
+ * 1. markdown document (string)
+ * 2. formatting options (int)
+ * 3. writer to use (int)
+ *
+ */
+static ERL_NIF_TERM render(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   ErlNifBinary  markdown_binary;
   ErlNifBinary  output_binary;
   cmark_node   *doc;
-  char         *html;
-  size_t        html_len;
-  int           options;
+  char         *output;
+  size_t        output_len;
+  int           options = 0;
+  int           format = 1;
 
-  if (argc != 2) {
+  if (argc != 3) {
     return enif_make_badarg(env);
   }
 
   if(!enif_inspect_binary(env, argv[0], &markdown_binary)){
+    return enif_make_badarg(env);
+  }
+
+  enif_get_int(env, argv[1], &options);
+
+  enif_get_int(env, argv[2], &format);
+
+  // Ensure we are not outside of the expected range of formats
+  if(format < 1 || format > 5){
     return enif_make_badarg(env);
   }
 
@@ -33,28 +59,45 @@ static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     return enif_make_binary(env, &output_binary);
   }
 
-  enif_get_int(env, argv[1], &options);
+  doc = cmark_parse_document((char *)markdown_binary.data,
+                                         markdown_binary.size,
+                                         options);
 
-  doc = cmark_parse_document(
-    (const char *)markdown_binary.data,
-    markdown_binary.size,
-    options
-  );
-  html = cmark_render_html(doc, options);
-  html_len = strlen(html);
+  switch (format) {
+    case FORMAT_HTML:
+      output = cmark_render_html(doc, options);
+      break;
+    case FORMAT_XML:
+      output = cmark_render_xml(doc, options);
+      break;
+    case FORMAT_MAN:
+      output = cmark_render_man(doc, options, 0);
+      break;
+    case FORMAT_COMMONMARK:
+      output = cmark_render_commonmark(doc, options, 0);
+      break;
+    case FORMAT_LATEX:
+      output = cmark_render_latex(doc, options, 0);
+      break;
+    default: // fallback to something that works
+      fprintf(stderr, "cmark_nif: unknown format %d\n", format);
+      output = cmark_render_commonmark(doc, options, 0);
+  }
+
+  output_len = strlen(output);
   enif_release_binary(&markdown_binary);
 
-  enif_alloc_binary(html_len, &output_binary);
-  strncpy((char*)output_binary.data, html, html_len);
+  enif_alloc_binary(output_len, &output_binary);
+  strncpy((char*)output_binary.data, output, output_len);
 
-  free(html);
+  free(output);
   cmark_node_free(doc);
 
   return enif_make_binary(env, &output_binary);
 };
 
 static ErlNifFunc nif_funcs[] = {
-  { "to_html", 2, to_html_nif }
+  { "render", 3, render }
 };
 
 ERL_NIF_INIT(Elixir.Cmark.Nif, nif_funcs, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This adds support for `to_latex`, `to_man`, `to_xml` and `to_commonmark `.

I'm not a huge fan of metaprogramming (I think it often obfuscates the source and makes changes difficult) but in this case it seems appropriate.

TODO:

- [ ] Fix docstrings so the documentation is a bit cleaner. I'm not sure how to do this well with the metaprogramming approach.
- [ ] Figure out what to do about mapping format atoms to integers for the C function.  Having the key:value map in the elixir and the C source is bad design.