### PR TITLE
Use ExDoc config only for docs env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
-config :ex_doc, :markdown_processor, ExDoc.Markdown.Cmark
+if Mix.env == :docs do
+  config :ex_doc, :markdown_processor, ExDoc.Markdown.Cmark
+end


### PR DESCRIPTION
… since it is a docs-only dependency and `iex -S mix` would complain about it otherwise.