### PR TITLE
Add more output formats

### DIFF
--- a/lib/cmark.ex
+++ b/lib/cmark.ex
@@ -1,53 +1,56 @@
 defmodule Cmark do
+  alias Cmark.Parser
+
   @moduledoc """
-  Compiles Markdown formatted text into HTML
+  Compiles Markdown formatted text into HTML or one of the other supported target formats.
 
   Provides:
 
+  * `to_commonmark/1`
+  * `to_commonmark/2`
+  * `to_commonmark/3`
+  * `to_commonmark_each/3`
   * `to_html/1`
   * `to_html/2`
   * `to_html/3`
   * `to_html_each/3`
+  * `to_latex/1`
+  * `to_latex/2`
+  * `to_latex/3`
+  * `to_latex_each/3`
+  * `to_man/1`
+  * `to_man/2`
+  * `to_man/3`
+  * `to_man_each/3`
+  * `to_xml/1`
+  * `to_xml/2`
+  * `to_xml/3`
+  * `to_xml_each/3`
 
   """
 
-  # c_src/cmark.h -> CMARK_OPT_*
-  @flags %{
-    sourcepos: 2,        # (1 <<< 1)
-    hardbreaks: 4,       # (1 <<< 2)
-    safe: 16,            # (1 <<< 3)
-    normalize: 256,      # (1 <<< 8)
-    validate_utf8: 512,  # (1 <<< 9)
-    smart: 1024,         # (1 <<< 10)
-  }
+  ##### HTML #####
 
-  @doc """
+  @doc ~S"""
   Compiles one or more (list) Markdown documents to HTML and returns result.
 
   ## Examples
 
       iex> "test" |> Cmark.to_html
-      "<p>test</p>\\n"
+      "<p>test</p>\n"
 
-      iex> ["# also works", "* with list", "`of documents`"] |> Cmark.to_html
-      ["<h1>also works</h1>\\n",
-      "<ul>\\n<li>with list</li>\\n</ul>\\n",
-      "<p><code>of documents</code></p>\\n"]
+      iex> ["test 1", "test 2"] |> Cmark.to_html
+      ["<p>test 1</p>\n", "<p>test 2</p>\n"]
 
   """
-  def to_html(data) when is_list(data) do
-    parse_doc_list(data, [])
-  end
+  def to_html(data),
+    do: Parser.parse(:html, data)
 
-  def to_html(data) when is_bitstring(data) do
-    parse_doc(data, [])
-  end
-
-  @doc """
+  @doc ~S"""
   Compiles one or more (list) Markdown documents to HTML using provided options
   and returns result.
 
-  Options are passed as a list of atoms.  Available options are:
+  Options are passed as a list of atoms. Available options are:
 
   * `:sourcepos` - Include a `data-sourcepos` attribute on all block elements.
   * `:softbreak` - Render `softbreak` elements as hard line breaks.
@@ -60,111 +63,436 @@ defmodule Cmark do
     `image/webp` mime types).  Raw HTML is replaced by a placeholder HTML
     comment. Unsafe links are replaced by empty strings.
 
-
   ## Examples
 
       iex> Cmark.to_html(~s(Use option to enable "smart" quotes.), [:smart])
-      "<p>Use option to enable “smart” quotes.</p>\\n"
+      "<p>Use option to enable “smart” quotes.</p>\n"
 
-  """
+  -----
 
-  def to_html(data, options) when is_list(data) and is_list(options) do
-    parse_doc_list(data, options)
-  end
-
-  def to_html(data, options) when is_bitstring(data) and is_list(options) do
-    parse_doc(data, options)
-  end
-
-  @doc """
   Compiles one or more (list) Markdown documents to HTML and calls function with result.
 
   ## Examples
 
-      iex> callback = fn (html) -> "HTML is \#{html}" |> String.strip end
-      iex> "test" |> Cmark.to_html(callback)
+      iex> callback = fn (result) -> "HTML is #{result}" |> String.strip end
+      iex> Cmark.to_html("test", callback)
       "HTML is <p>test</p>"
 
-      iex> callback = fn (htmls) ->
-      iex>   Enum.map(htmls, &String.strip/1) |> Enum.join("<hr>")
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("<hr>")
       iex> end
-      iex> ["list", "test"] |> Cmark.to_html(callback)
+      iex> Cmark.to_html(["list", "test"], callback)
       "<p>list</p><hr><p>test</p>"
 
   """
-  def to_html(data, callback) when is_list(data) and is_function(callback) do
-    parse_doc_list(data, callback, [])
-  end
+  def to_html(data, options_or_callback),
+    do: Parser.parse(:html, data, options_or_callback)
 
-  def to_html(data, callback) when is_bitstring(data) and is_function(callback) do
-    parse_doc(data, callback, [])
-  end
-
-  @doc """
+  @doc ~S"""
   Compiles one or more (list) Markdown documents to HTML using provided options
   and calls function with result.
 
   ## Examples
 
-      iex> callback = fn (htmls) ->
-      iex>   Enum.map(htmls, &String.strip/1) |> Enum.join("<hr>")
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("<hr>")
       iex> end
-      iex> ["en-dash --", "ellipsis..."] |> Cmark.to_html(callback, [:smart])
+      iex> Cmark.to_html(["en-dash --", "ellipsis..."], callback, [:smart])
       "<p>en-dash –</p><hr><p>ellipsis…</p>"
 
   """
-  def to_html(data, callback, options) when is_list(data) and is_function(callback) and is_list(options) do
-    parse_doc_list(data, callback, options)
-  end
+  def to_html(data, callback, options),
+    do: Parser.parse(:html, data, callback, options)
 
-  def to_html(data, callback, options) when is_bitstring(data) and is_function(callback) and is_list(options) do
-    parse_doc(data, callback, options)
-  end
+  @doc ~S"""
+  Compiles a list of Markdown documents to HTML and calls function for each item.
 
-  @doc """
-  Compiles a list of Markdown documents using provided options and calls
+  ## Examples
+
+      iex> callback = fn (result) -> "HTML is #{result |> String.strip}" end
+      iex> Cmark.to_html_each(["list", "test"], callback)
+      ["HTML is <p>list</p>", "HTML is <p>test</p>"]
+
+  """
+  def to_html_each(data, callback),
+    do: Parser.parse_each(:html, data, callback)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to HTML using provided options and calls
   function for each item.
 
   ## Examples
 
-      iex> callback = fn (html) -> "HTML is \#{html |> String.strip}" end
-      iex> ["list", "test"] |> Cmark.to_html_each(callback)
-      ["HTML is <p>list</p>", "HTML is <p>test</p>"]
+      iex> callback = fn (result) -> "HTML is #{result |> String.strip}" end
+      iex> Cmark.to_html_each(["list --", "test..."], callback, [:smart])
+      ["HTML is <p>list –</p>", "HTML is <p>test…</p>"]
 
   """
-  def to_html_each(data, callback, options \\ []) when is_list(data) do
-    parse_doc_list_each(data, callback, options)
-  end
+  def to_html_each(data, callback, options),
+    do: Parser.parse_each(:html, data, callback, options)
 
+  ##### XML #####
 
-  defp parse_doc_list(documents, callback, options) when is_function(callback) do
-    callback.(parse_doc_list(documents, options))
-  end
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to XML and returns result.
 
-  defp parse_doc_list(documents, options) when is_list(options) do
-    documents
-    |> Enum.map(&Task.async(fn -> parse_doc(&1, options) end))
-    |> Enum.map(&Task.await(&1))
-  end
+  ## Examples
 
+      iex> "test" |> Cmark.to_xml
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test</text>\n  </paragraph>\n</document>\n"
 
-  defp parse_doc_list_each(documents, callback, options) do
-    documents
-    |> Enum.map(&Task.async(fn -> parse_doc(&1, callback, options) end))
-    |> Enum.map(&Task.await(&1))
-  end
+      iex> ["test 1", "test 2"] |> Cmark.to_xml
+      ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test 1</text>\n  </paragraph>\n</document>\n",
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test 2</text>\n  </paragraph>\n</document>\n"]
 
+  """
+  def to_xml(data),
+    do: Parser.parse(:xml, data)
 
-  defp parse_doc(document, callback, options) do
-    callback.(parse_doc(document, options))
-  end
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to XML using provided options
+  and returns result.
 
-  defp parse_doc(document, options) do
-    Cmark.Nif.to_html(document, parse_options(options))
-  end
+  Options are passed as a list of atoms. For details see `Cmark.to_xml/2`.
 
+  ## Examples
 
-  defp parse_options(options) do
-    Enum.reduce(options, 0, fn(flag, acc) -> (@flags[flag] || 0) + acc end)
-  end
+      iex> Cmark.to_xml(~s(Use option to enable "smart" quotes.), [:smart])
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>Use option to enable </text>\n    <text>“</text>\n    <text>smart</text>\n    <text>”</text>\n    <text> quotes</text>\n    <text>.</text>\n  </paragraph>\n</document>\n"
+
+  -----
+
+  Compiles one or more (list) Markdown documents to XML and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "XML is #{result}" |> String.strip end
+      iex> Cmark.to_xml("test", callback)
+      "XML is <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test</text>\n  </paragraph>\n</document>"
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("<joiner>")
+      iex> end
+      iex> Cmark.to_xml(["list", "test"], callback)
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>list</text>\n  </paragraph>\n</document><joiner><?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test</text>\n  </paragraph>\n</document>"
+
+  """
+  def to_xml(data, options_or_callback),
+    do: Parser.parse(:xml, data, options_or_callback)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to XML using provided options
+  and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("<joiner>")
+      iex> end
+      iex> Cmark.to_xml(["en-dash --", "ellipsis..."], callback, [:smart])
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>en</text>\n    <text>-</text>\n    <text>dash </text>\n    <text>–</text>\n  </paragraph>\n</document><joiner><?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>ellipsis</text>\n    <text>…</text>\n  </paragraph>\n</document>"
+
+  """
+  def to_xml(data, callback, options),
+    do: Parser.parse(:xml, data, callback, options)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to XML and calls function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "XML is #{result |> String.strip}" end
+      iex> Cmark.to_xml_each(["list", "test"], callback)
+      ["XML is <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>list</text>\n  </paragraph>\n</document>",
+       "XML is <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test</text>\n  </paragraph>\n</document>"]
+
+  """
+  def to_xml_each(data, callback),
+    do: Parser.parse_each(:xml, data, callback)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to XML using provided options and calls
+  function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "XML is #{result |> String.strip}" end
+      iex> Cmark.to_xml_each(["list --", "test..."], callback, [:smart])
+      ["XML is <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>list </text>\n    <text>–</text>\n  </paragraph>\n</document>",
+       "XML is <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text>test</text>\n    <text>…</text>\n  </paragraph>\n</document>"]
+
+  """
+  def to_xml_each(data, callback, options),
+    do: Parser.parse_each(:xml, data, callback, options)
+
+  ##### Manpage #####
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to Manpage and returns result.
+
+  ## Examples
+
+      iex> "test" |> Cmark.to_man
+      ".PP\ntest\n"
+
+      iex> ["test 1", "test 2"] |> Cmark.to_man
+      [".PP\ntest 1\n", ".PP\ntest 2\n"]
+
+  """
+  def to_man(data),
+    do: Parser.parse(:man, data)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to Manpage using provided options
+  and returns result.
+
+  Options are passed as a list of atoms. For details see `Cmark.to_man/2`.
+
+  ## Examples
+
+      iex> Cmark.to_man(~s(Use option to enable "smart" quotes.), [:smart])
+      ".PP\nUse option to enable \\[lq]smart\\[rq] quotes.\n"
+
+  -----
+
+  Compiles one or more (list) Markdown documents to Manpage and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "Manpage is #{result}" |> String.strip end
+      iex> Cmark.to_man("test", callback)
+      "Manpage is .PP\ntest"
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("%%joiner%%")
+      iex> end
+      iex> Cmark.to_man(["list", "test"], callback)
+      ".PP\nlist%%joiner%%.PP\ntest"
+  """
+  def to_man(data, options_or_callback),
+    do: Parser.parse(:man, data, options_or_callback)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to Manpage using provided options
+  and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("%%joiner%%")
+      iex> end
+      iex> Cmark.to_man(["en-dash --", "ellipsis..."], callback, [:smart])
+      ".PP\nen\\-dash \\[en]%%joiner%%.PP\nellipsis…"
+
+  """
+  def to_man(data, callback, options),
+    do: Parser.parse(:man, data, callback, options)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to Manpage and calls function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "Manpage is #{result |> String.strip}" end
+      iex> Cmark.to_man_each(["list", "test"], callback)
+      ["Manpage is .PP\nlist", "Manpage is .PP\ntest"]
+
+  """
+  def to_man_each(data, callback),
+    do: Parser.parse_each(:man, data, callback)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to Manpage using provided options and calls
+  function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "Manpage is #{result |> String.strip}" end
+      iex> Cmark.to_man_each(["list --", "test..."], callback, [:smart])
+      ["Manpage is .PP\nlist \\[en]", "Manpage is .PP\ntest…"]
+
+  """
+  def to_man_each(data, callback, options),
+    do: Parser.parse_each(:man, data, callback, options)
+
+  ##### CommonMark #####
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to CommonMark and returns result.
+
+  ## Examples
+
+      iex> "test" |> Cmark.to_commonmark
+      "test\n"
+
+      iex> ["test 1", "test 2"] |> Cmark.to_commonmark
+      ["test 1\n", "test 2\n"]
+
+  """
+  def to_commonmark(data),
+    do: Parser.parse(:commonmark, data)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to CommonMark using provided options
+  and returns result.
+
+  Options are passed as a list of atoms. For details see `Cmark.to_commonmark/2`.
+
+  ## Examples
+
+      iex> Cmark.to_commonmark(~s(Use option to enable "smart" quotes.), [:smart])
+      "Use option to enable “smart” quotes.\n"
+
+  -----
+
+  Compiles one or more (list) Markdown documents to CommonMark and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "CommonMark is #{result}" |> String.strip end
+      iex> Cmark.to_commonmark("test", callback)
+      "CommonMark is test"
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("%%joiner%%")
+      iex> end
+      iex> Cmark.to_commonmark(["list", "test"], callback)
+      "list%%joiner%%test"
+  """
+  def to_commonmark(data, options_or_callback),
+    do: Parser.parse(:commonmark, data, options_or_callback)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to CommonMark using provided options
+  and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("%%joiner%%")
+      iex> end
+      iex> Cmark.to_commonmark(["en-dash --", "ellipsis..."], callback, [:smart])
+      "en-dash –%%joiner%%ellipsis…"
+
+  """
+  def to_commonmark(data, callback, options),
+    do: Parser.parse(:commonmark, data, callback, options)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to CommonMark and calls function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "CommonMark is #{result |> String.strip}" end
+      iex> Cmark.to_commonmark_each(["list", "test"], callback)
+      ["CommonMark is list", "CommonMark is test"]
+
+  """
+  def to_commonmark_each(data, callback),
+    do: Parser.parse_each(:commonmark, data, callback)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to CommonMark using provided options and calls
+  function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "CommonMark is #{result |> String.strip}" end
+      iex> Cmark.to_commonmark_each(["list --", "test..."], callback, [:smart])
+      ["CommonMark is list –", "CommonMark is test…"]
+
+  """
+  def to_commonmark_each(data, callback, options),
+    do: Parser.parse_each(:commonmark, data, callback, options)
+
+  ##### LaTeX #####
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to LaTeX and returns result.
+
+  ## Examples
+
+      iex> "test" |> Cmark.to_latex
+      "test\n"
+
+      iex> ["test 1", "test 2"] |> Cmark.to_latex
+      ["test 1\n", "test 2\n"]
+
+  """
+  def to_latex(data),
+    do: Parser.parse(:latex, data)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to LaTeX using provided options
+  and returns result.
+
+  Options are passed as a list of atoms. For details see `Cmark.to_latex/2`.
+
+  ## Examples
+
+      iex> Cmark.to_latex(~s(Use option to enable "smart" quotes.), [:smart])
+      "Use option to enable ``smart'' quotes.\n"
+
+  -----
+
+  Compiles one or more (list) Markdown documents to LaTeX and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "LaTeX is #{result}" |> String.strip end
+      iex> Cmark.to_latex("test", callback)
+      "LaTeX is test"
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("%%joiner%%")
+      iex> end
+      iex> Cmark.to_latex(["list", "test"], callback)
+      "list%%joiner%%test"
+  """
+  def to_latex(data, options_or_callback),
+    do: Parser.parse(:latex, data, options_or_callback)
+
+  @doc ~S"""
+  Compiles one or more (list) Markdown documents to LaTeX using provided options
+  and calls function with result.
+
+  ## Examples
+
+      iex> callback = fn (results) ->
+      iex>   Enum.map(results, &String.strip/1) |> Enum.join("%%joiner%%")
+      iex> end
+      iex> Cmark.to_latex(["en-dash --", "ellipsis..."], callback, [:smart])
+      "en-dash --%%joiner%%ellipsis\\ldots{}"
+
+  """
+  def to_latex(data, callback, options),
+    do: Parser.parse(:latex, data, callback, options)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to LaTeX and calls function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "LaTeX is #{result |> String.strip}" end
+      iex> Cmark.to_latex_each(["list", "test"], callback)
+      ["LaTeX is list", "LaTeX is test"]
+
+  """
+  def to_latex_each(data, callback),
+    do: Parser.parse_each(:latex, data, callback)
+
+  @doc ~S"""
+  Compiles a list of Markdown documents to LaTeX using provided options and calls
+  function for each item.
+
+  ## Examples
+
+      iex> callback = fn (result) -> "LaTeX is #{result |> String.strip}" end
+      iex> Cmark.to_latex_each(["list --", "test..."], callback, [:smart])
+      ["LaTeX is list --", "LaTeX is test\\ldots{}"]
+
+  """
+  def to_latex_each(data, callback, options),
+    do: Parser.parse_each(:latex, data, callback, options)
+
 end

--- a/lib/cmark/nif.ex
+++ b/lib/cmark/nif.ex
@@ -26,7 +26,7 @@ defmodule Cmark.Nif do
   end
 
   @doc false
-  def to_html(_, _) do
+  def render(_, _, _) do
     exit(:nif_library_not_loaded)
   end
 end

--- a/lib/cmark/parser.ex
+++ b/lib/cmark/parser.ex
@@ -1,0 +1,81 @@
+defmodule Cmark.Parser do
+  alias Cmark.Nif
+
+  @doc false
+  def parse(format, data) when is_list(data),
+    do: parse_doc_list(data, [], format)
+  def parse(format, data) when is_bitstring(data),
+    do: parse_doc(data, [], format)
+
+  @doc false
+  def parse(format, data, options) when is_list(data) and is_list(options),
+    do: parse_doc_list(data, options, format)
+  def parse(format, data, options) when is_bitstring(data) and is_list(options),
+    do: parse_doc(data, options, format)
+
+  @doc false
+  def parse(format, data, callback) when is_list(data) and is_function(callback),
+    do: parse_doc_list(data, callback, [], format)
+  def parse(format, data, callback) when is_bitstring(data) and is_function(callback),
+    do: parse_doc(data, callback, [], format)
+
+  @doc false
+  def parse(format, data, callback, options) when is_list(data) and is_function(callback) and is_list(options),
+    do: parse_doc_list(data, callback, options, format)
+  def parse(format, data, callback, options) when is_bitstring(data) and is_function(callback) and is_list(options),
+    do: parse_doc(data, callback, options, format)
+
+  @doc false
+  def parse_each(format, data, callback, options \\ []) when is_list(data),
+    do: parse_doc_list_each(data, callback, options, format)
+
+  @doc false
+  def parse_doc_list(documents, callback, options, format) when is_function(callback) do
+    callback.(parse_doc_list(documents, options, format))
+  end
+
+  @doc false
+  defp parse_doc_list(documents, options, format) when is_list(options) do
+    documents
+    |> Enum.map(&Task.async(fn -> parse_doc(&1, options, format) end))
+    |> Enum.map(&Task.await(&1))
+  end
+
+  @doc false
+  defp parse_doc_list_each(documents, callback, options, format) do
+    documents
+    |> Enum.map(&Task.async(fn -> parse_doc(&1, callback, options, format) end))
+    |> Enum.map(&Task.await(&1))
+  end
+
+
+  @doc false
+  defp parse_doc(document, callback, options, format),
+    do: callback.(parse_doc(document, options, format))
+
+  @doc false
+  defp parse_doc(document, options, format),
+    do: Nif.render(document, parse_options(options), format_id(format))
+
+  # c_src/cmark.h -> CMARK_OPT_*
+  @flags %{
+    sourcepos: 2,        # (1 <<< 1)
+    hardbreaks: 4,       # (1 <<< 2)
+    safe: 16,            # (1 <<< 3)
+    normalize: 256,      # (1 <<< 8)
+    validate_utf8: 512,  # (1 <<< 9)
+    smart: 1024,         # (1 <<< 10)
+  }
+
+  @doc false
+  defp parse_options(options),
+    do: Enum.reduce(options, 0, fn(flag, acc) -> @flags[flag] + acc end)
+
+  @doc false
+  defp format_id(:html), do: 1
+  defp format_id(:xml), do: 2
+  defp format_id(:man), do: 3
+  defp format_id(:commonmark), do: 4
+  defp format_id(:latex), do: 5
+  # defp format_id(_), do: 1
+end

--- a/src/cmark_nif.c
+++ b/src/cmark_nif.c
@@ -8,19 +8,44 @@
 #include "erl_nif.h"
 #include "cmark.h"
 
-static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+#define FORMAT_HTML 1
+#define FORMAT_XML 2
+#define FORMAT_MAN 3
+#define FORMAT_COMMONMARK 4
+#define FORMAT_LATEX 5
+
+/*
+ * Expose cmark parsers to Elixir via NIF
+ *
+ * Requires 3 arguments:
+ *
+ * 1. markdown document (string)
+ * 2. formatting options (int)
+ * 3. writer to use (int)
+ *
+ */
+static ERL_NIF_TERM render(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
   ErlNifBinary  markdown_binary;
   ErlNifBinary  output_binary;
   cmark_node   *doc;
-  char         *html;
-  size_t        html_len;
-  int           options;
+  char         *output;
+  size_t        output_len;
+  int           options = 0;
+  int           format = 1;
 
-  if (argc != 2) {
+  if (argc != 3) {
     return enif_make_badarg(env);
   }
 
   if(!enif_inspect_binary(env, argv[0], &markdown_binary)){
+    return enif_make_badarg(env);
+  }
+
+  enif_get_int(env, argv[1], &options);
+  enif_get_int(env, argv[2], &format);
+
+  // Ensure we are not outside of the expected range of formats
+  if(format < 1 || format > 5){
     return enif_make_badarg(env);
   }
 
@@ -33,28 +58,47 @@ static ERL_NIF_TERM to_html_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
     return enif_make_binary(env, &output_binary);
   }
 
-  enif_get_int(env, argv[1], &options);
-
   doc = cmark_parse_document(
     (const char *)markdown_binary.data,
     markdown_binary.size,
     options
   );
-  html = cmark_render_html(doc, options);
-  html_len = strlen(html);
+
+  switch (format) {
+    case FORMAT_HTML:
+      output = cmark_render_html(doc, options);
+      break;
+    case FORMAT_XML:
+      output = cmark_render_xml(doc, options);
+      break;
+    case FORMAT_MAN:
+      output = cmark_render_man(doc, options, 0);
+      break;
+    case FORMAT_COMMONMARK:
+      output = cmark_render_commonmark(doc, options, 0);
+      break;
+    case FORMAT_LATEX:
+      output = cmark_render_latex(doc, options, 0);
+      break;
+    default: // fallback to something that works
+      fprintf(stderr, "cmark_nif: unknown format %d\n", format);
+      output = cmark_render_commonmark(doc, options, 0);
+  }
+
+  output_len = strlen(output);
   enif_release_binary(&markdown_binary);
 
-  enif_alloc_binary(html_len, &output_binary);
-  strncpy((char*)output_binary.data, html, html_len);
+  enif_alloc_binary(output_len, &output_binary);
+  strncpy((char*)output_binary.data, output, output_len);
 
-  free(html);
+  free(output);
   cmark_node_free(doc);
 
   return enif_make_binary(env, &output_binary);
 };
 
 static ErlNifFunc nif_funcs[] = {
-  { "to_html", 2, to_html_nif }
+  { "render", 3, render }
 };
 
 ERL_NIF_INIT(Elixir.Cmark.Nif, nif_funcs, NULL, NULL, NULL, NULL);

--- a/test/cmark_formats_test.exs
+++ b/test/cmark_formats_test.exs
@@ -1,0 +1,4 @@
+defmodule CmarkFormatsTest do
+  use ExUnit.Case, async: true
+  doctest Cmark
+end

--- a/test/cmark_test.exs
+++ b/test/cmark_test.exs
@@ -1,6 +1,5 @@
 defmodule CmarkTest do
   use ExUnit.Case, async: true
-  doctest Cmark
 
   @cmark_specs File.read!("test/cmark_specs.json") |> Poison.decode!(keys: :atoms)
 


### PR DESCRIPTION
This adds support for XML, Manpage, CommonMark and LaTeX.

For the documentation and doctests I decided against complete deduplication of code and metaprogramming.
Maintainance cost in case of further formats is still pretty cheap, since one would only need to copy and adjust a section of a previous format.

-----

_Kudos to @tvon for the initial idea and PR #10!_