### PR TITLE
Correct the flag constant for :safe

### DIFF
--- a/lib/cmark/parser.ex
+++ b/lib/cmark/parser.ex
@@ -81,7 +81,7 @@ defmodule Cmark.Parser do
   @flags %{
     sourcepos: 2,        # (1 <<< 1)
     hardbreaks: 4,       # (1 <<< 2)
-    safe: 16,            # (1 <<< 3)
+    safe: 8,             # (1 <<< 3)
     normalize: 256,      # (1 <<< 8)
     validate_utf8: 512,  # (1 <<< 9)
     smart: 1024,         # (1 <<< 10)

--- a/test/cmark_test.exs
+++ b/test/cmark_test.exs
@@ -46,4 +46,24 @@ defmodule CmarkTest do
       assert actual_html == expected_html, error_message
     end
   end
+
+  @invalid_when_safe [
+    "<script>alert(document.cookie);</script>",
+    "</span>",
+    "<a href=\"https://example.com\">"
+  ]
+
+  for markdown <- @invalid_when_safe do
+    test "Removes HTML when :safe is set: #{markdown}" do
+      real_markdown = unquote(markdown)
+      actual_html  = Cmark.to_html(real_markdown, [:safe])
+      expected_html = "<!-- raw HTML omitted -->\n"
+      error_message = """
+      MARKDOWN: #{inspect real_markdown}
+      ACTUAL:   #{inspect actual_html}
+      EXPECTED: #{inspect expected_html}
+      """
+      assert actual_html == expected_html, error_message
+    end
+  end
 end


### PR DESCRIPTION
[The C source](https://github.com/asaaki/cmark.ex/blob/fcd022fe9a331c182919c600af4ae1c66463f2ed/c_src/cmark.h#L520) defines CMARK_OPT_SAFE as (1 << 3) and the comment [in parser.ex](https://github.com/asaaki/cmark.ex/blob/fcd022fe9a331c182919c600af4ae1c66463f2ed/lib/cmark/parser.ex#L69) is correct but (1 << 3) is 8 not 16.

```
# Broken
iex(1)> Cmark.to_html("<script>alert(document.cookie);</script>", [:safe])
"<script>alert(document.cookie);</script>\n"

# :safe = 16
iex(2)> Cmark.Nif.render("<script>alert(document.cookie);</script>", 16, 1)
"<script>alert(document.cookie);</script>\n"

# :safe should be 8
iex(3)> Cmark.Nif.render("<script>alert(document.cookie);</script>", 8, 1)
"<!-- raw HTML omitted -->\n"
```