### PR TITLE
Supresses a warning when running mix locally

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,17 +5,17 @@ defmodule Cmark.Mixfile do
 
   def project do
     [
-      app:           :cmark,
-      version:       @version,
-      elixir:        "~> 1.8",
-      compilers:     [:cmark, :elixir, :app],
-      deps:          deps(),
-      package:       package(),
-      description:   description(),
-      name:          "cmark",
-      source_url:    "https://github.com/asaaki/cmark.ex",
-      homepage_url:  "http://hexdocs.pm/cmark",
-      docs:          &docs/0,
+      app: :cmark,
+      version: @version,
+      elixir: "~> 1.8",
+      compilers: [:cmark, :elixir, :app],
+      deps: deps(),
+      package: package(),
+      description: description(),
+      name: "cmark",
+      source_url: "https://github.com/asaaki/cmark.ex",
+      homepage_url: "http://hexdocs.pm/cmark",
+      docs: &docs/0,
       test_coverage: [tool: ExCoveralls]
     ]
   end
@@ -31,12 +31,12 @@ defmodule Cmark.Mixfile do
 
   defp package do
     [
-      maintainers:  ["Christoph Grabo"],
-      licenses:     ["MIT"],
+      maintainers: ["Christoph Grabo"],
+      licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/asaaki/cmark.ex",
         "Issues" => "https://github.com/asaaki/cmark.ex/issues",
-        "Docs"   => "http://hexdocs.pm/cmark/#{@version}/"
+        "Docs" => "http://hexdocs.pm/cmark/#{@version}/"
       },
       files: [
         "c_src/*.h",
@@ -55,8 +55,8 @@ defmodule Cmark.Mixfile do
 
   defp docs do
     [
-      extras:     ["README.md"],
-      main:       "readme",
+      extras: ["README.md"],
+      main: "readme",
       source_ref: "v#{@version}",
       source_url: "https://github.com/asaaki/cmark.ex"
     ]
@@ -69,7 +69,7 @@ defmodule Cmark.Mixfile do
       {:excoveralls, "~> 0.6", only: :ci},
       {:inch_ex, "~> 2.0", only: [:docs, :ci]},
       {:jason, "~> 1.2", only: [:dev, :test, :docs, :lint, :ci], override: true},
-      {:dialyxir, "~> 1.0", only: [:dev]},
+      {:dialyxir, "~> 1.0", only: [:dev], runtime: false}
     ]
   end
 end
@@ -78,27 +78,31 @@ defmodule Mix.Tasks.Compile.Cmark do
   use Mix.Task
   @shortdoc "Compiles cmark library"
   def run(_) do
-    if Mix.env != :test, do: File.rm_rf("priv")
+    if Mix.env() != :test, do: File.rm_rf("priv")
     File.mkdir("priv")
 
-    make_cmd = System.get_env("MAKE") || case :os.type() do
-      {:unix, :freebsd} -> "gmake"
-      {:unix, :openbsd} -> "gmake"
-      {:unix, :netbsd} -> "gmake"
-      {:unix, :dragonfly} -> "gmake"
-      _ -> "make"
-    end
+    make_cmd =
+      System.get_env("MAKE") ||
+        case :os.type() do
+          {:unix, :freebsd} -> "gmake"
+          {:unix, :openbsd} -> "gmake"
+          {:unix, :netbsd} -> "gmake"
+          {:unix, :dragonfly} -> "gmake"
+          _ -> "make"
+        end
+
     {result, error_code} = System.cmd(make_cmd, [], stderr_to_stdout: true)
     IO.binwrite(result)
 
     if error_code != 0 do
-      raise Mix.Error, message: """
-        Could not run `#{make_cmd}`.
-        Please check if `make` and either `clang` or `gcc` are installed
-      """
+      raise Mix.Error,
+        message: """
+          Could not run `#{make_cmd}`.
+          Please check if `make` and either `clang` or `gcc` are installed
+        """
     end
 
-    Mix.Project.build_structure
+    Mix.Project.build_structure()
     :ok
   end
 end
@@ -107,6 +111,6 @@ defmodule Mix.Tasks.Spec do
   use Mix.Task
   @shortdoc "Runs spec test"
   def run(_) do
-    Mix.shell.cmd("make spec")
+    Mix.shell().cmd("make spec")
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,5 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"}
 }


### PR DESCRIPTION
Small thing I saw when building it locally:

On `master`, you'll find this warning after running

```bash
$ mix deps.get && mix

# [...]
Warning: the `dialyxir` application's start function was called, which likely means you                
  did not add the dependency with the `runtime: false` flag. This is not recommended because                                                                                                                       
  it will mean that unnecessary applications are started, and unnecessary applications are most          
  likely being added to your PLT file, increasing build time.                                                                                                                                                      
  Please add `runtime: false` in your `mix.exs` dependency section e.g.:                                 
  {:dialyxir, "~> 0.5", only: [:dev], runtime: false}         
```

This adds the `runtime: false`, as recommended.
