### PR TITLE
Minor docs changes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,0 @@
-# @deprecated; replace with `import Config`
-# once 1.9 is the last supported Elixir version
-use Mix.Config
-
-if Mix.env in ~w(dev docs ci)a do
-  config :ex_doc, :markdown_processor, ExDoc.Markdown.Cmark
-end

--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,7 @@ defmodule Cmark.Mixfile do
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/asaaki/cmark.ex",
-        "Issues" => "https://github.com/asaaki/cmark.ex/issues",
-        "Docs" => "http://hexdocs.pm/cmark/#{@version}/"
+        "Issues" => "https://github.com/asaaki/cmark.ex/issues"
       },
       files: [
         "c_src/*.h",


### PR DESCRIPTION
* Remove Docs link from mix.exs, Hex.pm already adds one like that

* Remove config/

  We've dropped support for cmark in ExDoc since we now operate on AST and we
  don't have support for it here. See https://github.com/elixir-lang/ex_doc/pull/1132.