### PR TITLE
Sets an absolute url for licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Latest API docs can be found at: <http://hexdocs.pm/cmark/Cmark.html>
 
 ## Licenses
 
--   Cmark.ex: [LICENSE](./LICENSE) (MIT)
--   cmark (C): [c_src/COPYING](./c_src/COPYING) (multiple)
+-   Cmark.ex: [LICENSE](https://github.com/asaaki/cmark.ex/blob/master/LICENSE) (MIT)
+-   cmark (C): [c_src/COPYING](https://github.com/asaaki/cmark.ex/blob/master/c_src/COPYING) (multiple)


### PR DESCRIPTION
If you view the docs generated by `ex_doc` on master (or hex.pm), you'll
get a 404 when viewing the source. It's a minor detail, but since we're
packing somebody elses lib, we should make sure Licenses can be viewed
correctly.

It's just something minor I found when reading through the docs.