### PR TITLE
Runs mix format

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,6 @@
+[
+  inputs: [
+    "{lib,config,test}/**/*.{ex,exs}",
+    "{mix,.formatter}.exs"
+  ]
+]

--- a/lib/cmark.ex
+++ b/lib/cmark.ex
@@ -33,13 +33,20 @@ defmodule Cmark do
 
   # c_src/cmark.h -> CMARK_OPT_*
   @flags %{
-    sourcepos: 2,        # (1 <<< 1)
-    hardbreaks: 4,       # (1 <<< 2)
-    nobreaks: 16,        # (1 <<< 4)
-    normalize: 256,      # (1 <<< 8)
-    validate_utf8: 512,  # (1 <<< 9)
-    smart: 1024,         # (1 <<< 10)
-    unsafe: 131072       # (1 <<< 17)
+    # (1 <<< 1)
+    sourcepos: 2,
+    # (1 <<< 2)
+    hardbreaks: 4,
+    # (1 <<< 4)
+    nobreaks: 16,
+    # (1 <<< 8)
+    normalize: 256,
+    # (1 <<< 9)
+    validate_utf8: 512,
+    # (1 <<< 10)
+    smart: 1024,
+    # (1 <<< 17)
+    unsafe: 131_072
   }
 
   @typedoc "A list of atoms describing the options to use (see module docs)"
@@ -57,7 +64,7 @@ defmodule Cmark do
       "<p>test</p>\n"
 
   """
-  @spec to_html(String.t, options_list) :: String.t
+  @spec to_html(String.t(), options_list) :: String.t()
   def to_html(document, options_list \\ [])
       when is_binary(document) and is_list(options_list) do
     convert(document, options_list, @html_id)
@@ -74,7 +81,7 @@ defmodule Cmark do
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\">\n  <paragraph>\n    <text xml:space=\"preserve\">test</text>\n  </paragraph>\n</document>\n"
 
   """
-  @spec to_xml(String.t, options_list) :: String.t
+  @spec to_xml(String.t(), options_list) :: String.t()
   def to_xml(document, options_list \\ [])
       when is_binary(document) and is_list(options_list) do
     convert(document, options_list, @xml_id)
@@ -91,7 +98,7 @@ defmodule Cmark do
       ".PP\ntest\n"
 
   """
-  @spec to_man(String.t, options_list) :: String.t
+  @spec to_man(String.t(), options_list) :: String.t()
   def to_man(document, options_list \\ [])
       when is_binary(document) and is_list(options_list) do
     convert(document, options_list, @man_id)
@@ -108,7 +115,7 @@ defmodule Cmark do
       "test\n"
 
   """
-  @spec to_commonmark(String.t, options_list) :: String.t
+  @spec to_commonmark(String.t(), options_list) :: String.t()
   def to_commonmark(document, options_list \\ [])
       when is_binary(document) and is_list(options_list) do
     convert(document, options_list, @commonmark_id)
@@ -125,7 +132,7 @@ defmodule Cmark do
       "test\n"
 
   """
-  @spec to_latex(String.t, options_list) :: String.t
+  @spec to_latex(String.t(), options_list) :: String.t()
   def to_latex(document, options_list \\ [])
       when is_binary(document) and is_list(options_list) do
     convert(document, options_list, @latex_id)

--- a/lib/cmark/nif.ex
+++ b/lib/cmark/nif.ex
@@ -10,7 +10,7 @@ defmodule Cmark.Nif do
   end
 
   @doc false
-  @spec render(String.t, integer, integer) :: String.t
+  @spec render(String.t(), integer, integer) :: String.t()
   def render(_data, _options, _format),
     do: exit(:nif_library_not_loaded)
 end

--- a/test/cmark_test.exs
+++ b/test/cmark_test.exs
@@ -6,7 +6,9 @@ defmodule CmarkTest do
     assert Cmark.to_man("") == "\n"
     assert Cmark.to_commonmark("") == "\n"
     assert Cmark.to_latex("") == "\n"
-    assert Cmark.to_xml("") == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\" />\n"
+
+    assert Cmark.to_xml("") ==
+             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n<document xmlns=\"http://commonmark.org/xml/1.0\" />\n"
   end
 
   test "UTF-8" do
@@ -38,13 +40,15 @@ defmodule CmarkTest do
   for markdown <- @invalid_when_safe do
     test "Removes HTML by default: #{markdown}" do
       real_markdown = unquote(markdown)
-      actual_html  = Cmark.to_html(real_markdown)
+      actual_html = Cmark.to_html(real_markdown)
       expected_html = "<!-- raw HTML omitted -->\n"
+
       error_message = """
-      MARKDOWN: #{inspect real_markdown}
-      ACTUAL:   #{inspect actual_html}
-      EXPECTED: #{inspect expected_html}
+      MARKDOWN: #{inspect(real_markdown)}
+      ACTUAL:   #{inspect(actual_html)}
+      EXPECTED: #{inspect(expected_html)}
       """
+
       assert actual_html == expected_html, error_message
     end
   end

--- a/test/specs_test.exs
+++ b/test/specs_test.exs
@@ -1,7 +1,7 @@
 defmodule Cmark.SpecsTest do
   use ExUnit.Case, async: true
 
-  @cmark_specs "test/cmark_specs.json" |> File.read! |> Jason.decode!(keys: :atoms)
+  @cmark_specs "test/cmark_specs.json" |> File.read!() |> Jason.decode!(keys: :atoms)
 
   for %{
         section: section,
@@ -13,13 +13,15 @@ defmodule Cmark.SpecsTest do
       } <- @cmark_specs do
     test "Section: »#{section}«, Example: #{example}, Lines: #{start_line}-#{end_line}" do
       real_markdown = unquote(markdown)
-      actual_html   = Cmark.to_html(real_markdown, [:unsafe])
+      actual_html = Cmark.to_html(real_markdown, [:unsafe])
       expected_html = unquote(html)
+
       error_message = """
-      MARKDOWN: #{inspect real_markdown}
-      ACTUAL:   #{inspect actual_html}
-      EXPECTED: #{inspect expected_html}
+      MARKDOWN: #{inspect(real_markdown)}
+      ACTUAL:   #{inspect(actual_html)}
+      EXPECTED: #{inspect(expected_html)}
       """
+
       assert actual_html == expected_html, error_message
     end
   end
@@ -28,7 +30,7 @@ end
 defmodule Cmark.SmartPunctTest do
   use ExUnit.Case, async: true
 
-  @cmark_smart_punct "test/cmark_smart_punct.json" |> File.read! |> Jason.decode!(keys: :atoms)
+  @cmark_smart_punct "test/cmark_smart_punct.json" |> File.read!() |> Jason.decode!(keys: :atoms)
 
   for %{
         section: section,
@@ -40,13 +42,15 @@ defmodule Cmark.SmartPunctTest do
       } <- @cmark_smart_punct do
     test "Section: »#{section}«, Example: #{example}, Lines: #{start_line}-#{end_line}" do
       real_markdown = unquote(markdown)
-      actual_html   = Cmark.to_html(real_markdown, [:smart])
+      actual_html = Cmark.to_html(real_markdown, [:smart])
       expected_html = unquote(html)
+
       error_message = """
-      MARKDOWN: #{inspect real_markdown}
-      ACTUAL:   #{inspect actual_html}
-      EXPECTED: #{inspect expected_html}
+      MARKDOWN: #{inspect(real_markdown)}
+      ACTUAL:   #{inspect(actual_html)}
+      EXPECTED: #{inspect(expected_html)}
       """
+
       assert actual_html == expected_html, error_message
     end
   end


### PR DESCRIPTION
For great consistency!

I run a pre-commit hook to check if the files match a simple `mix format` call. Since this crashed (the project was started before `mix format` was a thing, I disabled the hook, ran it separately and here are the changes.