### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dylib
 *.elf
 *.ez
+*.exp
 *.ko
 *.lib
 *.o
@@ -15,5 +16,6 @@
 /deps
 /doc
 /docs
+/Makefile.auto.win
 /tmp
 erl_crash.dump

--- a/Makefile.win
+++ b/Makefile.win
@@ -55,8 +55,8 @@ $(NIF_LIB): $(C_SRC_O_FILES)
     $(CC) $(CFLAGS) -I"$(ERTS_INCLUDE_PATH)" $(OPTIONS) $(C_SRC_O_FILES) $(NIF_SRC) -o $@
 
 !ELSE
-app: Makefile.auto.win
-	$(NMAKE) /F Makefile.win app
+$(NIF_LIB): Makefile.auto.win
+	$(NMAKE) /F Makefile.win $(NIF_LIB)
 !ENDIF
 
 {$(C_SRC_DIR)}.c{$(C_SRC_DIR)}.o:

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,63 @@
+### MVP for a NMake compatible version
+
+CC=clang
+NMAKE = nmake /$(MAKEFLAGS) /nologo
+
+!IF [where /Q Makefile.auto.win]
+# The file doesn't exist, so don't include it.
+!ELSE
+!INCLUDE Makefile.auto.win
+!ENDIF
+
+PRIV_DIR = priv
+SRC_DIR = src
+C_SRC_DIR = c_src
+# TODO: Find a way for nmake to support this pattern, too:
+# C_SRC_C_FILES = $(sort $(wildcard $(C_SRC_DIR)/*.c))
+C_SRC_C_FILES = \
+    $(C_SRC_DIR)\blocks.c \
+    $(C_SRC_DIR)\cmark.c \
+    $(C_SRC_DIR)\commonmark.c \
+    $(C_SRC_DIR)\houdini_html_e.c \
+    $(C_SRC_DIR)\html.c \
+    $(C_SRC_DIR)\iterator.c \
+    $(C_SRC_DIR)\man.c \
+    $(C_SRC_DIR)\references.c \
+    $(C_SRC_DIR)\scanners.c  \
+    $(C_SRC_DIR)\xml.c \
+    $(C_SRC_DIR)\buffer.c \
+    $(C_SRC_DIR)\cmark_ctype.c \
+    $(C_SRC_DIR)\houdini_href_e.c \
+    $(C_SRC_DIR)\houdini_html_u.c \
+    $(C_SRC_DIR)\inlines.c \
+    $(C_SRC_DIR)\latex.c \
+    $(C_SRC_DIR)\node.c \
+    $(C_SRC_DIR)\render.c \
+    $(C_SRC_DIR)\utf8.c
+C_SRC_O_FILES = $(C_SRC_C_FILES:.c=.o)
+NIF_SRC = $(SRC_DIR)\cmark_nif.c
+NIF_LIB=$(PRIV_DIR)\cmark.dll
+
+OPTIONS = -shared
+INCLUDES = -I"$(C_SRC_DIR)"
+CFLAGS = -target x86_64-pc-windows-msvc -O2 $(INCLUDES)
+CMARK_OPTFLAGS = -DNDEBUG
+
+all: $(NIF_LIB)
+
+Makefile.auto.win:
+	echo # Auto-generated as part of Makefile.win, do not modify. > $@
+	erl -eval "io:format(\"~s~n\", [lists:concat([\"ERTS_INCLUDE_PATH=\", code:root_dir(), \"/erts-\", erlang:system_info(version), \"/include\"])])" -s init stop -noshell >> $@
+
+!IFDEF ERTS_INCLUDE_PATH
+$(NIF_LIB): $(C_SRC_O_FILES)
+    if NOT EXIST "priv" mkdir "priv"
+    $(CC) $(CFLAGS) -I"$(ERTS_INCLUDE_PATH)" $(OPTIONS) $(C_SRC_O_FILES) $(NIF_SRC) -o $@
+
+!ELSE
+app: Makefile.auto.win
+	$(NMAKE) /F Makefile.win app
+!ENDIF
+
+{$(C_SRC_DIR)}.c{$(C_SRC_DIR)}.o:
+	$(CC) $(CMARK_OPTFLAGS) $(CFLAGS) -o $@ -c $<

--- a/README.windows.md
+++ b/README.windows.md
@@ -1,0 +1,29 @@
+# Windows compilation (Win10 64bit)
+
+Install Elixir on Windows:
+https://elixir-lang.org/install.html#windows
+
+Install Visual C++ BuildTools:
+https://visualstudio.microsoft.com/de/visual-cpp-build-tools/
+(or Visual Studio Community edition if you really want the whole package, but it's not needed)
+
+In the installer search for the `clang` in the individual components tab (the llvm version alone should be enough).
+
+_I have not succeeded with MSVC's compiler (`cl`) and also do not understand the flags well enough. So only clang support for now._
+
+In a powershell, switch to the project. Yes, switch first before doing the next line,
+for unknown reasons I couldn't switch drives once I called the vcvarsall.bat file.
+
+Most likely you want to run this:
+```shell
+cmd /K "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64
+```
+(unless you have already adjusted PATH and other env vars; but I guess it will also set other useful variables I'm not aware of.)
+
+### `Unspecified error`
+
+This should be a clear indicator that the DLL (or even the `.o` files) was compiled for the wrong target (x86 instead of x64).
+
+https://github.com/erlang/otp/blob/d6285b0a347b9489ce939511ee9a979acd868f71/erts/emulator/sys/win32/erl_win32_sys_ddll.c#L201-L234
+
+The error message could be better, but this is probably the only hint you will get when trying to load the NIF in a iex shell or in your application.

--- a/README.windows.md
+++ b/README.windows.md
@@ -1,15 +1,49 @@
 # Windows compilation (Win10 64bit)
 
-Install Elixir on Windows:
+_Some of the maintainers/contributors have tested it, but only with a Windows 10 64 bit version._
+_If you have a different version or architecture you might be out of luck._
+
+## Note for PowerShell usage
+
+You probably will need to run this unless you have already changed this due to other software on your computer:
+`Set-ExecutionPolicy -Scope CurrentUser -Policy RemoteSigned`
+
+References:
+- https://www.netiq.com/documentation/appmanager-modules/appmanagerforwindows/data/b116b7hm.html
+- https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7
+
+If you're a [chocolatey](https://chocolatey.org/) user you most likely have done this already and can go ahead.
+
+## Elixir installation
+
+Follow the instructions from the official Elixir documentation:
 https://elixir-lang.org/install.html#windows
 
-Install Visual C++ BuildTools:
+I haven't encountered anything tricky here, really nice installer based routine.
+
+## Visual C++ BuildTools
+
+Download the installer and run it:
 https://visualstudio.microsoft.com/de/visual-cpp-build-tools/
+
+You can also choose to insall a full Visual Studio environment instead if you plan to do more Windows development,
+then you need to search for the build tools in the installer, as VS does not automatically tick it depending on your desired configuration.
+
+You will need to switch to the individual components tab and search for `clang`
 (or Visual Studio Community edition if you really want the whole package, but it's not needed)
 
-In the installer search for the `clang` in the individual components tab (the llvm version alone should be enough).
+_I have not succeeded with MSVC's compiler (`cl`) and also do not understand the flags well enough. So only clang (llvm) support for now._
 
-_I have not succeeded with MSVC's compiler (`cl`) and also do not understand the flags well enough. So only clang support for now._
+### %PATH% adjustments for your environment variables
+
+Very tricky topic, but you need to figure out the full path to the `clang` bin folder (llvm version) and add it to your `%PATH%` environment variables configuration.
+
+Open a fresh PowerShell after this change.
+
+References:
+- https://developercommunity.visualstudio.com/idea/875419/how-to-use-msvc-installed-c-clang-tools-for-window.html
+
+## Compile this project
 
 In a powershell, switch to the project. Yes, switch first before doing the next line,
 for unknown reasons I couldn't switch drives once I called the vcvarsall.bat file.
@@ -20,6 +54,10 @@ cmd /K "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxili
 ```
 (unless you have already adjusted PATH and other env vars; but I guess it will also set other useful variables I'm not aware of.)
 
+Afterwards a valiantly typed `mix do deps.get, compile` should hopefully result in a great success.
+
+Try to open a shell with `iex -S mix` and run `Cmark.to_html("It works!")` — ideally no errors show up.
+
 ### `Unspecified error`
 
 This should be a clear indicator that the DLL (or even the `.o` files) was compiled for the wrong target (x86 instead of x64).
@@ -27,3 +65,24 @@ This should be a clear indicator that the DLL (or even the `.o` files) was compi
 https://github.com/erlang/otp/blob/d6285b0a347b9489ce939511ee9a979acd868f71/erts/emulator/sys/win32/erl_win32_sys_ddll.c#L201-L234
 
 The error message could be better, but this is probably the only hint you will get when trying to load the NIF in a iex shell or in your application.
+
+### Build artifacts leftovers and lots of hours
+
+When you did a compilation run and it failed, don't forget to clean the `c_src/*.o` files and the `priv` folder as well.
+Otherwise make will skip rebuilding some files and this could lead to unnecessarily spent hours.
+
+_I ran into issues with my shell and permissions and nmake and … so I had an explorer open and deleted such files by hand._
+
+### NMake
+
+Don't run `make` without arguments, it will try to use the (non-windows) Makefile which is incompatible with NMake.
+
+Specify the desired file like this:  `make /F Makefile.win <...>`.
+`mix compile` will automatically do that for you (with the great help of `elixir_make`).
+
+### Past experience and support
+
+For historical reference you can read the comments at https://github.com/asaaki/cmark.ex/pull/47 and see if anything else can help.
+
+While only being a fun exercise don't hesitate to [open an issue](hhttps://github.com/asaaki/cmark.ex/issues/new?title=Windows+compilation) 
+and we can work together to make it work for you if possible.


### PR DESCRIPTION
## Proposed Changes summary
  
  - Add a Makefile suitable for usage under Windows where NMake is usually the go-to tool
  - Ignore more files/extensions due to new temporary compilation artefacts
  - Add a readme document as a reminder on how to replicate the compilation under Windows

_After we introduced elixir_make with #39 I was curious about the Windows platform. Was not working out of the box, but with this change and the mentioned prerequisites it is actually possible._